### PR TITLE
📝🩹 Disable PDF build on RtD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,8 @@
 version: 2
 
 formats:
-  - pdf
   - htmlzip
+  # - pdf
 
 build:
   os: ubuntu-24.04
@@ -32,8 +32,8 @@ build:
         - uv run --frozen --no-dev --group docs -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
         - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
         - zip -r $READTHEDOCS_OUTPUT/htmlzip/html.zip docs/_build/dirhtml/*
-      pdf:
-        - uv run --frozen --no-dev --group docs -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
-        - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
-        - mkdir -p $READTHEDOCS_OUTPUT/pdf
-        - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf
+      # pdf:
+      #   - uv run --frozen --no-dev --group docs -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
+      #   - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
+      #   - mkdir -p $READTHEDOCS_OUTPUT/pdf
+      #   - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf


### PR DESCRIPTION
## Description

This PR disables the PDF build on RtD because it keeps failing us. It is a copy of https://github.com/munich-quantum-toolkit/core/pull/1023.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] ~~I have added appropriate tests and documentation.~~
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
