### PR TITLE
Decouple Fault Set functionality from state preparation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ ser = "ser"
 aer = "aer"
 anc = "anc"
 arange = "arange"
+nd = "nd"
 
 
 [tool.repo-review]

--- a/scripts/ft_stateprep/eval_det/eval.py
+++ b/scripts/ft_stateprep/eval_det/eval.py
@@ -15,12 +15,12 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING
 
-import mqt.qecc.ft_stateprep as ftsp
 import numpy as np
 import pandas as pd
 import qsample as qs
 from qiskit import QuantumCircuit
 
+import mqt.qecc.ft_stateprep as ftsp
 from mqt.qecc import codes
 
 if TYPE_CHECKING:

--- a/scripts/ft_stateprep/eval_det/plot.ipynb
+++ b/scripts/ft_stateprep/eval_det/plot.ipynb
@@ -9,6 +9,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "\n",
     "from mqt.qecc.ft_stateprep import DeterministicVerification"
    ]
   },

--- a/src/mqt/qecc/circuit_synthesis/__init__.py
+++ b/src/mqt/qecc/circuit_synthesis/__init__.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from .circuits import CNOTCircuit
 from .encoding import depth_optimal_encoding_circuit, gate_optimal_encoding_circuit, heuristic_encoding_circuit
 from .simulation import LutDecoder, NoisyNDFTStatePrepSimulator
 from .state_prep import (
@@ -26,6 +27,7 @@ from .state_prep_det import DeterministicVerification, DeterministicVerification
 from .synthesis_utils import qiskit_to_stim_circuit
 
 __all__ = [
+    "CNOTCircuit",
     "DeterministicVerification",
     "DeterministicVerificationHelper",
     "LutDecoder",

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Circuit representations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import stim
+from qiskit import QuantumCircuit
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable
+
+
+class CNOTCircuit:
+    """Represents a restricted quantum circuit composed of CNOT gates with optional qubit initialization."""
+
+    def __init__(self) -> None:
+        """Initialize an empty CNOT circuit."""
+        self.cnots: list[tuple[int, int]] = []
+        self.initializations: dict[int, str] = {}  # Dictionary mapping qubit index to initialization type ('Z' or 'X')
+
+    def add_cnot(self, control: int, target: int) -> None:
+        """Add a single CNOT gate to the circuit.
+
+        Args:
+            control: The control qubit index.
+            target: The target qubit index.
+        """
+        if control < 0 or target < 0:
+            msg = "Control and target qubits must have non-negative indices."
+            raise ValueError(msg)
+        if control == target:
+            msg = "Control and target qubits cannot be the same."
+            raise ValueError(msg)
+        self.cnots.append((control, target))
+
+    def add_cnots(self, cnot_pairs: Iterable[tuple[int, int]]) -> None:
+        """Add multiple CNOT gates to the circuit.
+
+        Args:
+            cnot_pairs: An iterable of (control, target) pairs.
+        """
+        for control, target in cnot_pairs:
+            self.add_cnot(control, target)
+
+    def initialize_qubit(self, qubit: int, basis: str) -> None:
+        """Initialize a qubit in the specified basis.
+
+        Args:
+            qubit: The qubit index to initialize.
+            basis: The basis for initialization ('Z' or 'X').
+        """
+        if qubit < 0:
+            msg = "Qubit index must be non-negative."
+            raise ValueError(msg)
+        if basis.capitalize() not in {"Z", "X"}:
+            msg = "Initialization basis must be 'Z' or 'X'."
+            raise ValueError(msg)
+        self.initializations[qubit] = basis
+
+    def to_stim_circuit(self) -> stim.Circuit:
+        """Convert the CNOT circuit to a stim.Circuit.
+
+        Returns:
+            A stim.Circuit representation of the CNOT circuit.
+        """
+        stim_circuit = stim.Circuit()
+
+        # Add initializations
+        for qubit, basis in self.initializations.items():
+            stim_circuit.append("R" + basis, [qubit])
+
+        # Add CNOT gates
+        stim_circuit.append_operation("CX", [qubit for pair in self.cnots for qubit in pair])
+
+        return stim_circuit
+
+    def to_qiskit_circuit(self) -> QuantumCircuit:
+        """Convert the CNOT circuit to a qiskit.QuantumCircuit.
+
+        Returns:
+            A qiskit.QuantumCircuit representation of the CNOT circuit.
+        """
+        return QuantumCircuit.from_qasm_str(self.to_stim_circuit().to_qasm(open_qasm_version=2))
+
+    def is_state(self) -> bool:
+        """Check if all qubits used in the circuit are initialized.
+
+        Returns:
+            True if all qubits involved in CNOT operations are initialized, False otherwise.
+        """
+        used_qubits = {qubit for control, target in self.cnots for qubit in (control, target)}
+        return used_qubits.issubset(self.initializations.keys())

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -98,3 +98,12 @@ class CNOTCircuit:
         """
         used_qubits = {qubit for control, target in self.cnots for qubit in (control, target)}
         return used_qubits.issubset(self.initializations.keys())
+
+    def num_qubits(self) -> int:
+        """Return the number of qubits used in the circuit.
+
+        The number of qubits is determined by the highest index of any CNOT control or target qubit,
+        """
+        cnot_indices = [qubit for control, target in self.cnots for qubit in (control, target)]
+        init_indices = list(self.initializations.keys())
+        return max(cnot_indices + init_indices, default=0) + 1

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -97,8 +97,11 @@ class CNOTCircuit:
 
         return stim_circuit
 
-    def to_qiskit_circuit(self, remove_resets=True) -> QuantumCircuit:
+    def to_qiskit_circuit(self, remove_resets: bool = True) -> QuantumCircuit:
         """Convert the CNOT circuit to a qiskit.QuantumCircuit.
+
+        Args:
+            remove_resets: If set to `True`, removes resets in the |0> state from the circuit.
 
         Returns:
             A qiskit.QuantumCircuit representation of the CNOT circuit.
@@ -210,13 +213,15 @@ class CNOTCircuit:
         return cnot_circuit
 
     @classmethod
-    def from_cnot_list(cls, cnots:Iterable[tuple[int, int]], initialize_z: Iterable[int], initialize_x: Iterable[int]) -> CNOTCircuit:
+    def from_cnot_list(
+        cls, cnots: Iterable[tuple[int, int]], initialize_z: Iterable[int], initialize_x: Iterable[int]
+    ) -> CNOTCircuit:
         """Construct CNOT circuit from list of CNOTs.
 
         Args:
             cnots: Control, target pairs defining CNOT interactions.
-            initiaize_z: Qubits that should be initialized in the Z-basis
-            initiaize_x: Qubits that should be initialized in the X-basis
+            initialize_z: Qubits that should be initialized in the Z-basis
+            initialize_x: Qubits that should be initialized in the X-basis
 
         Returns:
             CNOT circuit
@@ -224,9 +229,9 @@ class CNOTCircuit:
         cnot_circuit = cls()
         cnot_circuit.add_cnots(cnots)
         for q in initialize_z:
-            cnot_circuit.initialize_qubit(q, 'Z')
+            cnot_circuit.initialize_qubit(q, "Z")
         for q in initialize_x:
-            cnot_circuit.initialize_qubit(q, 'X')
+            cnot_circuit.initialize_qubit(q, "X")
         return cnot_circuit
 
     def is_state(self) -> bool:
@@ -304,6 +309,3 @@ class CNOTCircuit:
             path_lengths[target] = new_path_length
             path_lengths[control] = new_path_length
         return int(np.max(path_lengths))
-        
-        
-    

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import stim
 from qiskit import QuantumCircuit
+from qiskit.transpiler.passes import RemoveResetInZeroState
 
 from ..codes import CSSCode
 
@@ -96,13 +97,16 @@ class CNOTCircuit:
 
         return stim_circuit
 
-    def to_qiskit_circuit(self) -> QuantumCircuit:
+    def to_qiskit_circuit(self, remove_resets=True) -> QuantumCircuit:
         """Convert the CNOT circuit to a qiskit.QuantumCircuit.
 
         Returns:
             A qiskit.QuantumCircuit representation of the CNOT circuit.
         """
-        return QuantumCircuit.from_qasm_str(self.to_stim_circuit().to_qasm(open_qasm_version=2))
+        circ = QuantumCircuit.from_qasm_str(self.to_stim_circuit().to_qasm(open_qasm_version=2))
+        if remove_resets:
+            return RemoveResetInZeroState()(circ)
+        return circ
 
     @classmethod
     def from_qiskit_circuit(

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -68,6 +68,17 @@ class CNOTCircuit:
             raise ValueError(msg)
         self.initializations[qubit] = basis
 
+    def is_initialized(self, qubit: int) -> bool:
+        """Check if a qubit is initialized.
+
+        Args:
+            qubit: The qubit index to check.
+
+        Returns:
+            True if the qubit is initialized, False otherwise.
+        """
+        return qubit in self.initializations
+
     def to_stim_circuit(self) -> stim.Circuit:
         """Convert the CNOT circuit to a stim.Circuit.
 
@@ -92,6 +103,107 @@ class CNOTCircuit:
             A qiskit.QuantumCircuit representation of the CNOT circuit.
         """
         return QuantumCircuit.from_qasm_str(self.to_stim_circuit().to_qasm(open_qasm_version=2))
+
+    @classmethod
+    def from_qiskit_circuit(
+        cls, circ: QuantumCircuit, init_all: bool = False, initialized_qubits: Iterable[int] | None = None
+    ) -> CNOTCircuit:
+        """Construct a CNOT circuit from a qiskit `QuantumCircuit` object.
+
+        Generally, circ must contain only CNOT gates. The only exception to this is if `initialized_qubits` is given and the first gate on a qubit is a Hadamard gate. Then the qubit is initialized in |+>.
+
+        Args:
+            circ: The `QuantumCircuit` to construct the CNOT circuit from.
+            init_all: If set to `True`, all qubits are initialized.
+            initialized_qubits: Qubits to initialized.
+
+        Returns:
+            CNOTCircuit representation of the input circuit.
+        """
+        cnot_circuit = cls()
+        if initialized_qubits is None:
+            initialized_qubits = set()
+        else:
+            for qubit in initialized_qubits:
+                cnot_circuit.initialize_qubit(qubit, "Z")
+
+        # Initialize all qubits if `init_all` is True
+        if init_all:
+            for qubit in range(circ.num_qubits):
+                cnot_circuit.initialize_qubit(qubit, "Z")
+
+        initialized = [False for _ in range(circ.num_qubits)]
+        # Parse the circuit
+        for instruction in circ.data:
+            gate = instruction.operation
+            qubits = [circ.find_bit(q)[0] for q in instruction.qubits]
+
+            if gate.name == "h" and len(qubits) == 1:
+                qubit = qubits[0]
+                # Handle Hadamard gates for initialization
+                if initialized[qubit]:
+                    msg = f"Hadamard gate on qubit that is already initialized: {qubit}."
+                    raise ValueError(msg)
+                if qubit in initialized_qubits or init_all:
+                    cnot_circuit.initialize_qubit(qubit, "X")
+                    initialized[qubit] = True
+                else:
+                    msg = f"Hadamard gate on uninitialized qubit {qubit}."
+                    raise ValueError(msg)
+            elif gate.name == "cx" and len(qubits) == 2:
+                # Handle CNOT gates
+                cnot_circuit.add_cnot(qubits[0], qubits[1])
+                initialized[qubits[0]] = True
+                initialized[qubits[1]] = True
+            else:
+                msg = f"Unsupported gate {gate.name} in the circuit."
+                raise ValueError(msg)
+
+        return cnot_circuit
+
+    @classmethod
+    def from_stim_circuit(cls, circ: stim.Circuit) -> CNOTCircuit:
+        """Construct a CNOT circuit from a `stim.Circuit` object.
+
+        Generally, circ must contain only CNOT gates and initializations in the Z- or X-basis.
+
+        Args:
+            circ: The `stim.Circuit` to construct the CNOT circuit from.
+
+        Returns:
+            CNOTCircuit representation of the input circuit.
+        """
+        # determine which qubits are initialized in what basis.
+        cnot_circuit = cls()
+        initialized = [False for _ in range(circ.num_qubits)]
+        for gate in circ:
+            name = gate.name
+            for grp in gate.target_groups():
+                if name in {"R", "RZ"}:
+                    q = grp[0].qubit_value
+                    if initialized[q]:
+                        msg = f"Qubit {q} reset during circuit."
+                        raise ValueError(msg)
+                    cnot_circuit.initialize_qubit(grp[0].qubit_value, basis="Z")
+                    initialized[q] = True
+
+                elif name == "RX":
+                    q = grp[0].qubit_value
+                    if initialized[q]:
+                        msg = f"Qubit {q} reset during circuit."
+                        raise ValueError(msg)
+                    cnot_circuit.initialize_qubit(grp[0].qubit_value, basis="X")
+                    initialized[q] = True
+                elif name == "CX":
+                    control, target = grp[0].qubit_value, grp[1].qubit_value
+                    cnot_circuit.add_cnot(control, target)
+                    initialized[control] = True
+                    initialized[target] = True
+                else:
+                    msg = f"Unsupported gate {name} in the circuit."
+                    raise ValueError(msg)
+
+        return cnot_circuit
 
     def is_state(self) -> bool:
         """Check if all qubits used in the circuit are initialized.

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -287,3 +287,19 @@ class CNOTCircuit:
     def num_cnots(self) -> int:
         """Get number of CNOT gates in the circuit."""
         return len(self.cnots)
+
+    def depth(self) -> int:
+        """Get the depth of the circuit.
+
+        Returns:
+            The depth of the circuit.
+        """
+        path_lengths = np.zeros(self.num_qubits(), dtype=int)
+        for control, target in self.cnots:
+            new_path_length = max(path_lengths[control], path_lengths[target]) + 1
+            path_lengths[target] = new_path_length
+            path_lengths[control] = new_path_length
+        return int(np.max(path_lengths))
+        
+        
+    

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -205,6 +205,26 @@ class CNOTCircuit:
 
         return cnot_circuit
 
+    @classmethod
+    def from_cnot_list(cls, cnots:Iterable[tuple[int, int]], initialize_z: Iterable[int], initialize_x: Iterable[int]) -> CNOTCircuit:
+        """Construct CNOT circuit from list of CNOTs.
+
+        Args:
+            cnots: Control, target pairs defining CNOT interactions.
+            initiaize_z: Qubits that should be initialized in the Z-basis
+            initiaize_x: Qubits that should be initialized in the X-basis
+
+        Returns:
+            CNOT circuit
+        """
+        cnot_circuit = cls()
+        cnot_circuit.add_cnots(cnots)
+        for q in initialize_z:
+            cnot_circuit.initialize_qubit(q, 'Z')
+        for q in initialize_x:
+            cnot_circuit.initialize_qubit(q, 'X')
+        return cnot_circuit
+
     def is_state(self) -> bool:
         """Check if all qubits used in the circuit are initialized.
 
@@ -263,3 +283,7 @@ class CNOTCircuit:
             hz[:, ctrl] ^= hz[:, trgt]
 
         return CSSCode(hx, hz)
+
+    def num_cnots(self) -> int:
+        """Get number of CNOT gates in the circuit."""
+        return len(self.cnots)

--- a/src/mqt/qecc/circuit_synthesis/circuits.py
+++ b/src/mqt/qecc/circuit_synthesis/circuits.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import stim
 from qiskit import QuantumCircuit
+
+from ..codes import CSSCode
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterable
@@ -107,3 +110,44 @@ class CNOTCircuit:
         cnot_indices = [qubit for control, target in self.cnots for qubit in (control, target)]
         init_indices = list(self.initializations.keys())
         return max(cnot_indices + init_indices, default=0) + 1
+
+    def get_plus_initialized(self) -> list[int]:
+        """Get the list of qubits initialized in the |+> state.
+
+        Returns:
+            A list of qubit indices initialized in the |+> state.
+        """
+        return [qubit for qubit, basis in self.initializations.items() if basis.upper() == "X"]
+
+    def get_zero_initialized(self) -> list[int]:
+        """Get the list of qubits initialized in the |0> state.
+
+        Returns:
+            A list of qubit indices initialized in the |0> state.
+        """
+        return [qubit for qubit, basis in self.initializations.items() if basis.upper() == "Z"]
+
+    def get_code(self) -> CSSCode:
+        """Get CSS code defined by the circuit.
+
+        A CNOT circuit with |0> and |+> initializations is the encoding isometry of some CSS code.
+        The code is obtained by propagating the stabilizers of the initialized qubits to the end of the circuit.
+        Qubits initialized in |+> define X-type stabilizers, while qubits initialized in |0> define Z-type stabilizers.
+
+        Returns:
+            A CSSCode object representing the code defined by the circuit.
+        """
+        pluses = self.get_plus_initialized()
+        zeros = self.get_zero_initialized()
+        hx = np.zeros((len(pluses), self.num_qubits()), dtype=np.int8)
+        hz = np.zeros((len(zeros), self.num_qubits()), dtype=np.int8)
+        for i, qubit in enumerate(pluses):
+            hx[i, qubit] = 1
+        for i, qubit in enumerate(zeros):
+            hz[i, qubit] = 1
+
+        for ctrl, trgt in self.cnots:
+            hx[:, trgt] ^= hx[:, ctrl]
+            hz[:, ctrl] ^= hz[:, trgt]
+
+        return CSSCode(hx, hz)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -49,20 +49,21 @@ class PureFaultSet:
             raise ValueError(msg)
         self.faults = np.vstack([self.faults, fault])
 
-    def add_faults(self, faults:npt.NDArray[np.int8]) -> None:
+    def add_faults(self, faults: npt.NDArray[np.int8]) -> None:
         """Add multiple faults to the fault set.
 
         Args:
-            fault: A 2D numpy array representing a collection of faults.
+            faults: A 2D numpy array representing a collection of faults.
         """
         self.faults = np.vstack((self.faults, faults))
-        
-    def combine(self, other: PureFaultSet, inplace=False) -> PureFaultSet:
+
+    def combine(self, other: PureFaultSet, inplace: bool = False) -> PureFaultSet:
         """Combine this fault set with another fault set.
 
         Args:
             other: Another PureFaultSet to combine with.
             inplace: If True, modifies self.
+
         Returns:
             A new PureFaultSet representing the combined faults.
         """
@@ -329,7 +330,7 @@ class PureFaultSet:
         undetectable_indices = self._get_undetectable_faults_idx(stabs)
         self.faults = np.delete(self.faults, undetectable_indices, axis=0)
 
-    def filter_faults(self, pred: Callable[npt.NDArray[np.int8], bool], inplace=True) -> PureFaultSet:
+    def filter_faults(self, pred: Callable[[npt.NDArray[np.int8]], bool], inplace: bool = True) -> PureFaultSet:
         """Filter faults by removing faults for which the given predicate is False.
 
         This method modifies the fault set in place, removing faults that do not satisfy the predicate.
@@ -341,7 +342,7 @@ class PureFaultSet:
         filtered = np.array([fault for fault in self.faults if pred(fault)], dtype=np.int8)
         if filtered.size == 0:
             filtered = np.zeros((0, self.num_qubits), dtype=np.int8)
-            
+
         if inplace:
             self.faults = filtered
             return self

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -299,7 +299,7 @@ class PureFaultSet:
         """
         return bool(np.all(np.any(stabs @ self.faults.T % 2, axis=1)))
 
-    def _get_undetectable_faults_idx(self, stabs: npt.NDArray[np.int8]) -> npt.NDArray[int]:
+    def get_undetectable_faults_idx(self, stabs: npt.NDArray[np.int8]) -> npt.NDArray[int]:
         """Return indices of faults that are not detectable by the given stabilizers.
 
         Args:
@@ -319,7 +319,7 @@ class PureFaultSet:
         Returns:
             A 2D numpy array where each row is a fault that commutes with all generators.
         """
-        return self.faults[self._get_undetectable_faults_idx(stabs)]
+        return self.faults[self.get_undetectable_faults_idx(stabs)]
 
     def remove_undetectable_faults(self, stabs: npt.NDArray[np.int8]) -> None:
         """Remove all faults that are not detectable by the given stabilizers.
@@ -327,7 +327,7 @@ class PureFaultSet:
         Args:
             stabs: A 2D numpy array where each row is a stabilizer generator.
         """
-        undetectable_indices = self._get_undetectable_faults_idx(stabs)
+        undetectable_indices = self.get_undetectable_faults_idx(stabs)
         self.faults = np.delete(self.faults, undetectable_indices, axis=0)
 
     def filter_faults(self, pred: Callable[[npt.NDArray[np.int8]], bool], inplace: bool = True) -> PureFaultSet:

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -18,7 +18,7 @@ from ldpc import mod2
 from .synthesis_utils import symbolic_vector_add, symbolic_vector_eq, vars_to_stab
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Callable
 
     import numpy.typing as npt
 
@@ -316,6 +316,16 @@ class PureFaultSet:
         """
         undetectable_indices = self._get_undetectable_faults_idx(stabs)
         self.faults = np.delete(self.faults, undetectable_indices, axis=0)
+
+    def filter_faults(self, pred: Callable[npt.NDArray[np.int8], bool]) -> None:
+        """Filter faults by removing faults for which the given predicate is False.
+
+        This method modifies the fault set in place, removing faults that do not satisfy the predicate.
+        
+        Args:
+            pred: A callable that takes a fault (1D numpy array) and returns True if the fault should be kept.
+        """
+        self.faults = np.array([fault for fault in self.faults if pred(fault)], dtype=np.int8)
 
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -140,10 +140,24 @@ class PureFaultSet:
         # Reduce all faults to their coset representatives
         for i, fault in enumerate(self.faults):
             # Identify the indices of pivot columns where the fault has a 1
-            active_pivots = [p for p in pivots if fault[p] == 1]
+            active_pivots = [pivots.index(p) for p in pivots if fault[p] == 1]
             if active_pivots:  # Ensure there are active pivots to reduce with
                 self.faults[i] = fault ^ np.bitwise_xor.reduce(rref[active_pivots], axis=0)
 
+    def remove_zero_rows(self) -> None:
+        """Remove all zero rows from the fault set.
+
+        This method modifies the fault set in place, removing any rows that are entirely zero.
+        """
+        self.faults = self.faults[np.any(self.faults, axis=1)]
+
+    def remove_duplicates(self) -> None:
+        """Remove duplicate faults from the fault set.
+
+        This method modifies the fault set in place, ensuring that each fault is unique.
+        """
+        self.faults = np.unique(self.faults, axis=0)
+        
     def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
         """Remove faults belonging to the same coset with respect to the stabilizer group.
 
@@ -153,8 +167,8 @@ class PureFaultSet:
         self.normalize(stabs)
 
         # remove all zero rows
-        self.faults = self.faults[np.any(self.faults, axis=1)]
-        self.faults = np.unique(self.faults, axis=0)
+        self.remove_zero_rows()
+        self.remove_duplicates()
 
     def to_set(self) -> set[tuple[int, ...]]:
         """Convert the fault set to a set of tuples for easier comparison."""
@@ -232,6 +246,14 @@ class PureFaultSet:
         """Return a string representation of the PureFaultSet."""
         return f"PureFaultSet(num_qubits={self.num_qubits}, faults={self.faults.tolist()})"
 
+    def __len__(self) -> int:
+        """Return the number of faults in the PureFaultSet.
+
+        Returns:
+            The number of faults.
+        """
+        return self.faults.shape[0]
+
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
     """Compute the coset leader of a fault given a set of stabilizer generators."""
@@ -251,7 +273,7 @@ def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) 
     return np.array([bool(m[leader[i]]) for i in range(len(fault))]).astype(int)
 
 
-def fault_set_product(lhs: PureFaultSet, rhs: PureFaultSet) -> PureFaultSet:
+def product_fault_set(lhs: PureFaultSet, rhs: PureFaultSet) -> PureFaultSet:
     """Generate fault set by forming the product of all faults of two fault sets.
 
     Args:
@@ -290,3 +312,6 @@ def stabilizer_equivalent(lhs: PureFaultSet, rhs: PureFaultSet, stabs: npt.NDArr
         rhs_cpy.normalize(stabs)
 
     return lhs_cpy == rhs_cpy
+
+
+  

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -18,7 +18,7 @@ from ldpc import mod2
 from .synthesis_utils import symbolic_vector_add, symbolic_vector_eq, vars_to_stab
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Iterator, Callable
+    from collections.abc import Callable, Iterator
 
     import numpy.typing as npt
 
@@ -317,15 +317,21 @@ class PureFaultSet:
         undetectable_indices = self._get_undetectable_faults_idx(stabs)
         self.faults = np.delete(self.faults, undetectable_indices, axis=0)
 
-    def filter_faults(self, pred: Callable[npt.NDArray[np.int8], bool]) -> None:
+    def filter_faults(self, pred: Callable[npt.NDArray[np.int8], bool], inplace=True) -> PureFaultSet:
         """Filter faults by removing faults for which the given predicate is False.
 
         This method modifies the fault set in place, removing faults that do not satisfy the predicate.
-        
+
         Args:
             pred: A callable that takes a fault (1D numpy array) and returns True if the fault should be kept.
+            inplace: If True, modifies the current fault set. If False, returns a new PureFaultSet with filtered faults.
         """
-        self.faults = np.array([fault for fault in self.faults if pred(fault)], dtype=np.int8)
+        filtered = np.array([fault for fault in self.faults if pred(fault)], dtype=np.int8)
+        if inplace:
+            self.faults = filtered
+            return self
+
+        return PureFaultSet.from_fault_array(filtered)
 
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -37,7 +37,7 @@ class PureFaultSet:
         self.num_qubits = num_qubits
         self.faults = np.zeros((0, num_qubits), dtype=np.int8)  # Pure faults as binary vectors
 
-    def add_fault(self, fault: np.ndarray) -> None:
+    def add_fault(self, fault: npt.NDArray[np.int8]) -> None:
         """Add a fault to the fault set.
 
         Args:
@@ -49,12 +49,20 @@ class PureFaultSet:
             raise ValueError(msg)
         self.faults = np.vstack([self.faults, fault])
 
-    def combine(self, other: PureFaultSet) -> PureFaultSet:
+    def add_faults(self, faults:npt.NDArray[np.int8]) -> None:
+        """Add multiple faults to the fault set.
+
+        Args:
+            fault: A 2D numpy array representing a collection of faults.
+        """
+        self.faults = np.vstack((self.faults, faults))
+        
+    def combine(self, other: PureFaultSet, inplace=False) -> PureFaultSet:
         """Combine this fault set with another fault set.
 
         Args:
             other: Another PureFaultSet to combine with.
-
+            inplace: If True, modifies self.
         Returns:
             A new PureFaultSet representing the combined faults.
         """
@@ -62,6 +70,10 @@ class PureFaultSet:
             msg = "Fault sets must have the same number of qubits to combine."
             raise ValueError(msg)
         combined_faults = np.vstack([self.faults, other.faults])
+
+        if inplace:
+            self.faults = combined_faults
+            return self
         return PureFaultSet.from_fault_array(combined_faults)
 
     def to_array(self) -> npt.NDArray[np.int8]:
@@ -327,6 +339,9 @@ class PureFaultSet:
             inplace: If True, modifies the current fault set. If False, returns a new PureFaultSet with filtered faults.
         """
         filtered = np.array([fault for fault in self.faults if pred(fault)], dtype=np.int8)
+        if filtered.size == 0:
+            filtered = np.zeros((0, self.num_qubits), dtype=np.int8)
+            
         if inplace:
             self.faults = filtered
             return self

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import z3
 from ldpc import mod2
+
+from .synthesis_utils import symbolic_vector_add, symbolic_vector_eq, vars_to_stab
 
 if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
@@ -79,12 +82,13 @@ class PureFaultSet:
         return fault_set
 
     @classmethod
-    def from_cnot_circuit(cls, circ: CNOTCircuit, kind: str = "X") -> PureFaultSet:
+    def from_cnot_circuit(cls, circ: CNOTCircuit, kind: str = "X", reduce: bool = False) -> PureFaultSet:
         """Generate a PureFaultSet from a CNOT circuit.
 
         Args:
             circ: The CNOT circuit to generate faults from.
             kind: The type of faults to generate ('X' or 'Z').
+            reduce: Reduce faults by stabilizers induced by the circuit.
 
         Returns:
             A PureFaultSet containing the faults generated from the circuit.
@@ -102,7 +106,15 @@ class PureFaultSet:
             qubit_faults[ctrl].append(new_fault)
 
         # Create the fault set
-        return cls.from_fault_array(np.array([fault for faults in qubit_faults for fault in faults], dtype=np.int8))
+        fs = cls.from_fault_array(np.array([fault for faults in qubit_faults for fault in faults], dtype=np.int8))
+        if not reduce:
+            return fs
+
+        code = circ.get_code()
+        stabs = code.Hx if kind == "X" else code.Hz
+
+        fs.remove_equivalent(stabs)
+        return fs
 
     def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
         """Remove faults belonging to the same coset with respect to the stabilizer group."""
@@ -133,3 +145,37 @@ class PureFaultSet:
     def to_set(self) -> set[tuple[int, ...]]:
         """Convert the fault set to a set of tuples for easier comparison."""
         return set(map(tuple, self.faults))
+
+    def faults_to_coset_leaders(self, generators: npt.NDArray[np.int8]) -> None:
+        """Map all faults in the set to their coset leaders with respect to the stabilizer generators.
+
+        This method modifies the fault set in place, replacing each fault with its coset leader.
+        Warning: This might take a while.
+
+        Args:
+            generators: A 2D numpy array where each row is a stabilizer generator.
+        """
+        if generators.ndim != 2 or generators.shape[1] != self.num_qubits:
+            msg = f"Generators must be a 2D array with {self.num_qubits} columns."
+            raise ValueError(msg)
+
+        self.faults = np.array([coset_leader(fault, generators) for fault in self.faults], dtype=np.int8)
+        self.faults = np.unique(self.faults, axis=0)
+
+
+def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
+    """Compute the coset leader of a fault given a set of stabilizer generators."""
+    if len(generators) == 0:
+        return fault
+    s = z3.Optimize()
+    leader = [z3.Bool(f"e_{i}") for i in range(len(fault))]
+    coeff = [z3.Bool(f"c_{i}") for i in range(len(generators))]
+
+    g = vars_to_stab(coeff, generators)
+
+    s.add(symbolic_vector_eq(np.array(leader), symbolic_vector_add(fault.astype(bool), g)))
+    s.minimize(z3.Sum(leader))
+
+    s.check()  # always SAT
+    m = s.model()
+    return np.array([bool(m[leader[i]]) for i in range(len(fault))]).astype(int)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Functionality for handling collections of circuit faults."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from ldpc import mod2
+
+if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
+
+    from .circuits import CNOTCircuit
+
+
+class PureFaultSet:
+    """Represents a collection of pure faults (X-type or Z-type) in a quantum circuit."""
+
+    def __init__(self, num_qubits: int) -> None:
+        """Initialize a PureFaultSet object.
+
+        Args:
+            num_qubits: The number of qubits in the circuit.
+        """
+        self.num_qubits = num_qubits
+        self.faults = np.zeros((0, num_qubits), dtype=np.int8)  # Pure faults as binary vectors
+
+    def add_fault(self, fault: np.ndarray) -> None:
+        """Add a fault to the fault set.
+
+        Args:
+            fault: A 1D numpy array representing the fault. The array must have length ~num_qubits~.
+        """
+        fault = np.asarray(fault, dtype=np.int8)
+        if fault.shape[0] != self.num_qubits:
+            msg = f"Fault must have length {self.num_qubits}."
+            raise ValueError(msg)
+        self.faults = np.vstack([self.faults, fault])
+
+    def combine(self, other: PureFaultSet) -> PureFaultSet:
+        """Combine this fault set with another fault set.
+
+        Args:
+            other: Another PureFaultSet to combine with.
+
+        Returns:
+            A new PureFaultSet representing the combined faults.
+        """
+        if self.num_qubits != other.num_qubits:
+            msg = "Fault sets must have the same number of qubits to combine."
+            raise ValueError(msg)
+        combined_faults = np.vstack([self.faults, other.faults])
+        return PureFaultSet.from_fault_array(combined_faults)
+
+    def to_array(self) -> npt.NDArray[np.int8]:
+        """Convert the fault set to a numpy array.
+
+        Returns:
+            A 2D numpy array where each row represents a fault.
+        """
+        return self.faults
+
+    @classmethod
+    def from_fault_array(cls, array: npt.NDArray[np.int8]) -> PureFaultSet:
+        """Create a PureFaultSet from a numpy array of faults.
+
+        Returns:
+            A PureFaultSet object containing the faults.
+        """
+        fault_set = cls(array.shape[1])
+        fault_set.faults = np.unique(array, axis=0)
+        return fault_set
+
+    @classmethod
+    def from_cnot_circuit(cls, circ: CNOTCircuit, kind: str = "X") -> PureFaultSet:
+        """Generate a PureFaultSet from a CNOT circuit.
+
+        Args:
+            circ: The CNOT circuit to generate faults from.
+            kind: The type of faults to generate ('X' or 'Z').
+
+        Returns:
+            A PureFaultSet containing the faults generated from the circuit.
+        """
+        assert kind.capitalize() in {"X", "Z"}, "Kind must be either 'X' or 'Z'."
+        num_qubits = circ.num_qubits()
+        qubit_faults = [[fault] for fault in np.eye(num_qubits, dtype=np.int8)]
+
+        # iterate through circuit in reverse and combine faults
+        for control, target in reversed(circ.cnots):
+            ctrl, trgt = control, target
+            if kind == "Z":
+                ctrl, trgt = trgt, ctrl
+            new_fault = qubit_faults[ctrl][-1] ^ qubit_faults[trgt][-1]
+            qubit_faults[ctrl].append(new_fault)
+
+        # Create the fault set
+        return cls.from_fault_array(np.array([fault for faults in qubit_faults for fault in faults], dtype=np.int8))
+
+    def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
+        """Remove faults belonging to the same coset with respect to the stabilizer group."""
+        if stabs.shape[1] != self.num_qubits:
+            msg = f"Stabilizer matrix must have {self.num_qubits} columns."
+            raise ValueError(msg)
+        if stabs.ndim != 2:
+            msg = "Stabilizer matrix must be 2-dimensional."
+            raise ValueError(msg)
+        if self.faults.size == 0:
+            return
+        if stabs.shape[0] == 0:
+            # If stabilizer matrix is empty, no faults can be removed
+            return
+
+        rref, _, _, pivots = mod2.row_echelon(stabs, full=True)
+        # Reduce all faults to their coset representatives
+        for i, fault in enumerate(self.faults):
+            # Identify the indices of pivot columns where the fault has a 1
+            active_pivots = [p for p in pivots if fault[p] == 1]
+            if active_pivots:  # Ensure there are active pivots to reduce with
+                self.faults[i] = fault ^ np.bitwise_xor.reduce(rref[active_pivots], axis=0)
+
+        # remove all zero rows
+        self.faults = self.faults[np.any(self.faults, axis=1)]
+        self.faults = np.unique(self.faults, axis=0)
+
+    def to_set(self) -> set[tuple[int, ...]]:
+        """Convert the fault set to a set of tuples for easier comparison."""
+        return set(map(tuple, self.faults))

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -18,6 +18,8 @@ from ldpc import mod2
 from .synthesis_utils import symbolic_vector_add, symbolic_vector_eq, vars_to_stab
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterator
+
     import numpy.typing as npt
 
     from .circuits import CNOTCircuit
@@ -252,7 +254,7 @@ class PureFaultSet:
         Returns:
             The number of faults.
         """
-        return self.faults.shape[0]
+        return int(self.faults.shape[0])
 
     def __getitem__(self, index: int) -> npt.NDArray[np.int8]:
         """Get a fault by index.
@@ -265,7 +267,7 @@ class PureFaultSet:
         """
         return self.faults[index]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[npt.NDArray[np.int8]]:
         """Return an iterator over the faults in the PureFaultSet.
 
         Returns:
@@ -282,7 +284,7 @@ class PureFaultSet:
         Returns:
             True if every fault anticommutes with at least one generator, False otherwise
         """
-        return np.all(np.any(stabs @ self.faults.T % 2, axis=1))
+        return bool(np.all(np.any(stabs @ self.faults.T % 2, axis=1)))
 
     def _get_undetectable_faults_idx(self, stabs: npt.NDArray[np.int8]) -> npt.NDArray[int]:
         """Return indices of faults that are not detectable by the given stabilizers.
@@ -295,7 +297,7 @@ class PureFaultSet:
         """
         return np.where(np.all(stabs @ self.faults.T % 2 == 0, axis=1))[0]
 
-    def get_undetectable_faults(self, stabs: npt.NDArray[np.int8]) -> bool:
+    def get_undetectable_faults(self, stabs: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
         """Return faults that are not detectable by the given stabilizers.
 
         Args:

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -157,7 +157,7 @@ class PureFaultSet:
         This method modifies the fault set in place, ensuring that each fault is unique.
         """
         self.faults = np.unique(self.faults, axis=0)
-        
+
     def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
         """Remove faults belonging to the same coset with respect to the stabilizer group.
 
@@ -272,7 +272,48 @@ class PureFaultSet:
             An iterator over the faults.
         """
         return iter(self.faults)
-        
+
+    def all_faults_detected(self, stabs: npt.NDArray[np.int8]) -> bool:
+        """Check whether all faults in the set are detected by the given stabilizers.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+
+        Returns:
+            True if every fault anticommutes with at least one generator, False otherwise
+        """
+        return np.all(np.any(stabs @ self.faults.T % 2, axis=1))
+
+    def _get_undetectable_faults_idx(self, stabs: npt.NDArray[np.int8]) -> npt.NDArray[int]:
+        """Return indices of faults that are not detectable by the given stabilizers.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+
+        Returns:
+            Indices of faults that commute with all generators.
+        """
+        return np.where(np.all(stabs @ self.faults.T % 2 == 0, axis=1))[0]
+
+    def get_undetectable_faults(self, stabs: npt.NDArray[np.int8]) -> bool:
+        """Return faults that are not detectable by the given stabilizers.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+
+        Returns:
+            A 2D numpy array where each row is a fault that commutes with all generators.
+        """
+        return self.faults[self._get_undetectable_faults_idx(stabs)]
+
+    def remove_undetectable_faults(self, stabs: npt.NDArray[np.int8]) -> None:
+        """Remove all faults that are not detectable by the given stabilizers.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+        """
+        undetectable_indices = self._get_undetectable_faults_idx(stabs)
+        self.faults = np.delete(self.faults, undetectable_indices, axis=0)
 
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
@@ -332,6 +373,3 @@ def stabilizer_equivalent(lhs: PureFaultSet, rhs: PureFaultSet, stabs: npt.NDArr
         rhs_cpy.normalize(stabs)
 
     return lhs_cpy == rhs_cpy
-
-
-  

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -254,6 +254,26 @@ class PureFaultSet:
         """
         return self.faults.shape[0]
 
+    def __getitem__(self, index: int) -> npt.NDArray[np.int8]:
+        """Get a fault by index.
+
+        Args:
+            index: The index of the fault to retrieve.
+
+        Returns:
+            A 1D numpy array representing the fault.
+        """
+        return self.faults[index]
+
+    def __iter__(self):
+        """Return an iterator over the faults in the PureFaultSet.
+
+        Returns:
+            An iterator over the faults.
+        """
+        return iter(self.faults)
+        
+
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
     """Compute the coset leader of a fault given a set of stabilizer generators."""

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -176,7 +176,7 @@ class PureFaultSet:
         self.faults = np.array([coset_leader(fault, generators) for fault in self.faults], dtype=np.int8)
         self.faults = np.unique(self.faults, axis=0)
 
-    def filter_by_weight(self, w: int, stabs: npt.NDArray[np.int8]) -> None:
+    def filter_by_weight_at_least(self, w: int, stabs: npt.NDArray[np.int8]) -> None:
         """Filter faults by weight with respect to a stabilizer group.
 
         A fault is removed if its coset leader has weight lower than w.

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -116,8 +116,14 @@ class PureFaultSet:
         fs.remove_equivalent(stabs)
         return fs
 
-    def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
-        """Remove faults belonging to the same coset with respect to the stabilizer group."""
+    def normalize(self, stabs: npt.NDArray[np.int8]) -> None:
+        """Normalize the faults with respect to a stabilizer group.
+
+        A fault is considered normalized if its entries in the pivot columns of the RREF of the stabilizer matrix are zero.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+        """
         if stabs.shape[1] != self.num_qubits:
             msg = f"Stabilizer matrix must have {self.num_qubits} columns."
             raise ValueError(msg)
@@ -137,6 +143,14 @@ class PureFaultSet:
             active_pivots = [p for p in pivots if fault[p] == 1]
             if active_pivots:  # Ensure there are active pivots to reduce with
                 self.faults[i] = fault ^ np.bitwise_xor.reduce(rref[active_pivots], axis=0)
+
+    def remove_equivalent(self, stabs: npt.NDArray[np.int8]) -> None:
+        """Remove faults belonging to the same coset with respect to the stabilizer group.
+
+        Args:
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+        """
+        self.normalize(stabs)
 
         # remove all zero rows
         self.faults = self.faults[np.any(self.faults, axis=1)]
@@ -162,6 +176,62 @@ class PureFaultSet:
         self.faults = np.array([coset_leader(fault, generators) for fault in self.faults], dtype=np.int8)
         self.faults = np.unique(self.faults, axis=0)
 
+    def filter_by_weight(self, w: int, stabs: npt.NDArray[np.int8]) -> None:
+        """Filter faults by weight with respect to a stabilizer group.
+
+        A fault is removed if its coset leader has weight lower than w.
+        This operation also removes stabilizer equivalent errors and maps faults to their coset leaders.
+
+        Args:
+            w: Weight faults are filtered by.
+            stabs: A 2D numpy array where each row is a stabilizer generator.
+        """
+        self.remove_equivalent(stabs)
+        self.faults_to_coset_leaders(stabs)
+
+        # filter remaining faults by weight
+        weights = np.sum(self.faults, axis=1)
+        mask = weights >= w
+        self.faults = self.faults[mask]
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality of two PureFaultSet objects.
+
+        Two PureFaultSet objects are considered equal if they have the same number of qubits
+        and contain the same faults. This check does not factor in stabilizer equivalence or coset leaders.
+
+        Args:
+            other: Another PureFaultSet object to compare with.
+
+        Returns:
+            True if both PureFaultSet objects are equal, False otherwise.
+        """
+        if not isinstance(other, PureFaultSet):
+            return False
+        return self.num_qubits == other.num_qubits and self.to_set() == other.to_set()
+
+    def __hash__(self) -> int:
+        """Return a hash of the PureFaultSet.
+
+        Returns:
+            An integer hash value.
+        """
+        return hash((self.num_qubits, tuple(map(tuple, self.faults))))
+
+    def copy(self) -> PureFaultSet:
+        """Create a copy of the PureFaultSet.
+
+        Returns:
+            A new PureFaultSet object with the same faults and number of qubits.
+        """
+        new_set = PureFaultSet(self.num_qubits)
+        new_set.faults = np.copy(self.faults)
+        return new_set
+
+    def __repr__(self) -> str:
+        """Return a string representation of the PureFaultSet."""
+        return f"PureFaultSet(num_qubits={self.num_qubits}, faults={self.faults.tolist()})"
+
 
 def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
     """Compute the coset leader of a fault given a set of stabilizer generators."""
@@ -179,3 +249,44 @@ def coset_leader(fault: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) 
     s.check()  # always SAT
     m = s.model()
     return np.array([bool(m[leader[i]]) for i in range(len(fault))]).astype(int)
+
+
+def fault_set_product(lhs: PureFaultSet, rhs: PureFaultSet) -> PureFaultSet:
+    """Generate fault set by forming the product of all faults of two fault sets.
+
+    Args:
+        lhs: The first fault set.
+        rhs: The second fault set.
+
+    Returns:
+        Fault set containing all products of faults of lhs and rhs.
+    """
+    if lhs.num_qubits != rhs.num_qubits:
+        msg = "Fault sets must have the same number of qubits to combine."
+        raise ValueError(msg)
+    new_faults = (lhs.faults[:, np.newaxis, :] ^ rhs.faults).reshape(-1, lhs.num_qubits)
+    return PureFaultSet.from_fault_array(new_faults)
+
+
+def stabilizer_equivalent(lhs: PureFaultSet, rhs: PureFaultSet, stabs: npt.NDArray[np.int8] | None) -> bool:
+    """Check if two fault sets are equivalent with respect to a stabilizer group.
+
+    Args:
+            lhs: The first fault set.
+            rhs: The second fault set.
+            stabs (optional): A 2D numpy array where each row is a stabilizer generator.
+
+    Returns:
+            True if the two fault sets are equivalent with respect to the stabilizer group, False otherwise.
+    """
+    if lhs.num_qubits != rhs.num_qubits:
+        msg = "Fault sets must have the same number of qubits to compare."
+        raise ValueError(msg)
+
+    lhs_cpy = lhs.copy()
+    rhs_cpy = rhs.copy()
+    if stabs is not None:
+        lhs_cpy.normalize(stabs)
+        rhs_cpy.normalize(stabs)
+
+    return lhs_cpy == rhs_cpy

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -414,7 +414,7 @@ def all_gate_optimal_verification_stabilizers(
                 measurements = cnot_opt
             else:
                 break
-        logger.info(f"Minimal number of CNOTs for {layer} errors is: {num_cnots}")
+        logger.info(f"Minimal number of CNOTs for {layer+1} errors is: {num_cnots}")
 
         # If the number of CNOTs is minimal, we can reduce the number of ancillas
         logger.info(f"Finding minimal number of ancillas for {layer + 1} errors")

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -114,7 +114,7 @@ class StatePrepCircuit:
             fs.remove_zero_rows()
             fs.remove_duplicates()
 
-            fault_sets_unreduced[num_errors] = fs.copy()
+        fault_sets_unreduced[num_errors] = fs.copy()
 
         # reduce faults by stabilizer
         stabs = self.x_checks if x_errors else self.z_checks
@@ -146,17 +146,17 @@ class StatePrepCircuit:
         if len(additional_faults) == 0:
             return fault_sets
 
-        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors)]
+        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors+1)]
         new_products[1] = additional_faults
         for i in range(2, self.max_errors):
             new_products[i] = product_fault_set(new_products[1], new_products[i-1])
 
-        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors)+1]
-        new_fault_sets = [None for _ in range(self.max_errors)+1]
-        for i in range(1, self.max_errors):
+        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors+1)]
+        new_fault_sets = [None for _ in range(self.max_errors+1)]
+        for i in range(1, self.max_errors+1):
             fs = fault_sets_unreduced[i].copy()
             fs.combine(new_products[i])
-            for j in range(1, i):
+            for j in range(2, i):
                 k = i - j
                 prod = product_fault_set(new_products[j], new_products[k])
                 fs.combine(prod)
@@ -346,7 +346,7 @@ def all_gate_optimal_verification_stabilizers(
     for layer in range(n_layers):
         logger.info(f"Finding verification stabilizers for {layer} errors")
         faults = fault_sets[layer]
-
+        
         if len(faults) == 0:
             logger.info(f"No non-trivial faults for {layer} errors")
             layers[layer] = []
@@ -432,7 +432,7 @@ def all_gate_optimal_verification_stabilizers(
                 faults, stabs, num_anc, num_cnots, return_all_solutions=True
             )
             if all_stabs:
-                layers[layer - 1] = all_stabs
+                layers[layer] = all_stabs
                 logger.info(f"Found {len(layers[layer])} equivalent solutions for {layer} errors")
 
     return layers
@@ -441,39 +441,41 @@ def all_gate_optimal_verification_stabilizers(
 def _verification_circuit(
     sp_circ: StatePrepCircuit,
     verification_stabs_fun: Callable[
-        [list[PureFaultSet]], list[list[npt.NDArray[np.int8]]]
+        [list[PureFaultSet], npt.NDArray[np.int8]], list[list[npt.NDArray[np.int8]]]
     ],
-    full_fault_tolerance: bool = True,
+    verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     logger.info("Finding verification stabilizers for the state preparation circuit")
-    layers_1 = verification_stabs_fun(sp_circ.x_fault_sets[1:])
-    measurements_1 = [measurement for layer in layers_1 for measurement in layer]
 
-    if full_fault_tolerance:
-        if not flag_first_layer:
-            additional_errors = get_hook_errors(measurements_1)
-            extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors=False)
-            layers_2 = verification_stabs_fun(extended_fault_sets[1:])
-        else:
-            layers_2 = verification_stabs_fun(sp_circ.z_fault_sets[1:])
-        measurements_2 = [measurement for layer in layers_2 for measurement in layer]
+    if verify_x_first:
+        first_fault_sets = sp_circ.x_fault_sets[1:]
+        first_checks = sp_circ.z_checks
+        second_fault_sets = sp_circ.z_fault_sets[1:]
+        second_checks = sp_circ.x_checks
     else:
-        measurements_2 = []
+        first_fault_sets = sp_circ.z_fault_sets[1:]
+        first_checks = sp_circ.x_checks
+        second_fault_sets = sp_circ.x_fault_sets[1:]
+        second_checks = sp_circ.z_checks
 
-    if sp_circ.zero_state:
-        return _measure_ft_stabs(
-            sp_circ,
-            measurements_2,
-            measurements_1,
-            full_fault_tolerance=full_fault_tolerance,
-            flag_first_layer=flag_first_layer,
-        )
+    layers_1 = verification_stabs_fun(first_fault_sets, first_checks)
+    measurements_1 = [measurement for layer in layers_1 for measurement in layer]        
+    if not flag_first_layer:
+        additional_errors = get_hook_errors(measurements_1)
+        extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors= not verify_x_first)
+        layers_2 = verification_stabs_fun(extended_fault_sets[1:], second_checks)
+    else:
+        layers_2 = verification_stabs_fun(second_fault_sets, second_checks)
+    measurements_2 = [measurement for layer in layers_2 for measurement in layer]
+
+    z_measurements = measurements_1 if verify_x_first else measurements_2
+    x_measurements = measurements_2 if verify_x_first else measurements_1
     return _measure_ft_stabs(
         sp_circ,
-        measurements_1,
-        measurements_2,
-        full_fault_tolerance=full_fault_tolerance,
+        x_measurements,
+        z_measurements,
+        verify_x_first=verify_x_first,
         flag_first_layer=flag_first_layer,
     )
 
@@ -483,7 +485,7 @@ def gate_optimal_verification_circuit(
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
-    full_fault_tolerance: bool = True,
+    verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     r"""Return a verified state preparation circuit.
@@ -502,14 +504,14 @@ def gate_optimal_verification_circuit(
     """
 
     def verification_stabs_fun(
-        fault_sets: list[PureFaultSet],
+        fault_sets: list[PureFaultSet], stabs: npt.NDArray[np.int8]
     ) -> list[list[npt.NDArray[np.int8]]]:
         return gate_optimal_verification_stabilizers(
-            fault_sets, min_timeout, max_timeout, max_ancillas
+            fault_sets, stabs, min_timeout, max_timeout, max_ancillas
         )
 
     return _verification_circuit(
-        sp_circ, verification_stabs_fun, full_fault_tolerance=full_fault_tolerance, flag_first_layer=flag_first_layer
+        sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
     )
 
 
@@ -540,7 +542,7 @@ def heuristic_verification_circuit(
         )
 
     return _verification_circuit(
-        sp_circ, verification_stabs_fun, full_fault_tolerance=full_fault_tolerance, flag_first_layer=flag_first_layer
+        sp_circ, verification_stabs_fun, verify_x_first=full_fault_tolerance, flag_first_layer=flag_first_layer
     )
 
 
@@ -731,22 +733,22 @@ def _measure_ft_stabs(
     sp_circ: StatePrepCircuit,
     x_measurements: list[npt.NDArray[np.int8]],
     z_measurements: list[npt.NDArray[np.int8]],
-    full_fault_tolerance: bool = True,
+    verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     # Create the verification circuit
     q = QuantumRegister(sp_circ.num_qubits, "q")
     measured_circ = QuantumCircuit(q)
-    measured_circ.compose(sp_circ.circ, inplace=True)
+    measured_circ.compose(sp_circ.circ.to_qiskit_circuit(), inplace=True)
 
-    if sp_circ.zero_state:
-        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_x_errors, flags=flag_first_layer)
-        if full_fault_tolerance:
-            _measure_ft_x(measured_circ, x_measurements, flags=True, t=sp_circ.max_x_errors)
+    if verify_x_first:
+        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_errors, flags=flag_first_layer)
+        _measure_ft_x(measured_circ, x_measurements, flags=True, t=sp_circ.max_errors)
+
     else:
-        _measure_ft_x(measured_circ, x_measurements, t=sp_circ.max_z_errors, flags=flag_first_layer)
-        if full_fault_tolerance:
-            _measure_ft_z(measured_circ, z_measurements, flags=True, t=sp_circ.max_z_errors)
+        _measure_ft_x(measured_circ, x_measurements, flags=flag_first_layer, t=sp_circ.max_errors)
+        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_errors)
+    
 
     return measured_circ
 
@@ -790,17 +792,18 @@ def all_verification_stabilizers(
         num_cnots: The maximum number of CNOT gates to use.
         return_all_solutions: If True, return all solutions. Otherwise, return the first solution found.
     """
+
     # Measurements are written as sums of generators
     # The variables indicate which generators are non-zero in the sum
     if fault_set.faults.shape[1] != stabs.shape[1]:
         msg = "Fault set and stabilizers must have the same number of qubits."
         raise ValueError(msg)
-
+    
     # Check if fault set can be verified, i.e., every fault can be detected by at least one measurement
-    if any(np.any(fault_set.faults@ stabs.T % 2 == 0, axis=1)):
+    if any(np.all(fault_set.faults@ stabs.T % 2 == 0, axis=1)):
         logger.warning("Fault set cannot be verified by the given stabilizers. Some faults are not detectable by the given stabilizers.")
         return None
-    
+
     n_gens = stabs.shape[0]
     n_qubits = stabs.shape[1]
 

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -519,7 +519,7 @@ def heuristic_verification_circuit(
     sp_circ: StatePrepCircuit,
     max_covering_sets: int = 10000,
     find_coset_leaders: bool = True,
-    full_fault_tolerance: bool = True,
+    verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     r"""Return a verified state preparation circuit.
@@ -535,20 +535,20 @@ def heuristic_verification_circuit(
     """
 
     def verification_stabs_fun(
-        sp_circ: StatePrepCircuit, zero_state: bool, additional_errors: npt.NDArray[np.int8] | None = None
+        fault_sets: list[PureFaultSet], stabs: npt.NDArray[np.int8]
     ) -> list[list[npt.NDArray[np.int8]]]:
         return heuristic_verification_stabilizers(
-            sp_circ, zero_state, max_covering_sets, find_coset_leaders, additional_errors
+            fault_sets, stabs, max_covering_sets, find_coset_leaders
         )
 
     return _verification_circuit(
-        sp_circ, verification_stabs_fun, verify_x_first=full_fault_tolerance, flag_first_layer=flag_first_layer
+        sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
     )
 
 
 def heuristic_verification_stabilizers(
-    sp_circ: StatePrepCircuit,
-    x_errors: bool = True,
+    fault_sets: list[PureFaultSet],
+    stabs: npt.NDArray[np.int8],
     max_covering_sets: int = 10000,
     find_coset_leaders: bool = True,
     additional_faults: npt.NDArray[np.int8] | None = None,
@@ -563,27 +563,19 @@ def heuristic_verification_stabilizers(
         additional_faults: Faults to verify in addition to the faults propagating in the state preparation circuit.
     """
     logger.info("Finding verification stabilizers using heuristic method")
-    max_errors = sp_circ.max_errors
-    layers: list[list[npt.NDArray[np.int8]]] = [[] for _ in range(max_errors)]
-    sp_circ.compute_fault_sets()
-    fault_sets = (
-        sp_circ.combine_faults(additional_faults, x_errors)
-        if additional_faults is not None
-        else sp_circ.x_fault_sets
-        if x_errors
-        else sp_circ.z_fault_sets
-    )
-    orthogonal_checks = sp_circ.z_checks if x_errors else sp_circ.x_checks
-    for num_errors in range(1, max_errors + 1):
+    n_layers = len(fault_sets)
+    layers: list[list[npt.NDArray[np.int8]]] = [[] for _ in range(n_layers)]
+
+    for num_errors in range(0, n_layers):
         logger.info(f"Finding verification stabilizers for {num_errors} errors")
         faults = fault_sets[num_errors]
         assert faults is not None
         logger.info(f"There are {len(faults)} faults")
         if len(faults) == 0:
-            layers[num_errors - 1] = []
+            layers[num_errors] = []
             continue
 
-        layers[num_errors - 1] = _heuristic_layer(faults, orthogonal_checks, find_coset_leaders, max_covering_sets)
+        layers[num_errors] = _heuristic_layer(faults.faults, stabs, find_coset_leaders, max_covering_sets)
 
     return layers
 

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -37,8 +37,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
 
     import numpy.typing as npt
-    from qiskit import DAGNode
-    from qiskit.quantum_info import PauliList
 
     from ..codes.css_code import CSSCode
 
@@ -46,14 +44,12 @@ if TYPE_CHECKING:  # pragma: no cover
 class StatePrepCircuit:
     """Represents a state preparation circuit for a CSS code."""
 
-    def __init__(self, circ: CNOTCircuit, max_errors: int, error_detection_code: bool = False) -> None:
+    def __init__(self, circ: CNOTCircuit, max_errors: int | tuple[int, int]) -> None:
         """Initialize a state preparation circuit.
 
         Args:
             circ: The state preparation circuit.
-            code: The CSS code to prepare the state for.
-            zero_state: If True, prepare the +1 eigenstate of the Z basis. If False, prepare the +1 eigenstate of the X basis.
-            error_detection_code: If True, prepare the state for error detection. This ensures that when computing the fault set of the circuit, up to d//2 errors errors can occur in the circuit.
+            max_errors: Maximum errors that can happen in the circuit. If tuple is given, different numbers of X- and Z-errors can occur.
         """
         if not circ.is_state():
             msg = "Input circuit is not a state!"
@@ -62,19 +58,23 @@ class StatePrepCircuit:
         self.circ = circ
         code = circ.get_code()
         self.num_qubits = circ.num_qubits()
-        self.max_errors = max_errors
+        if isinstance(max_errors, int):
+            self.max_x_errors = max_errors
+            self.max_z_errors = max_errors
+        else:
+            self.max_x_errors, self.max_z_errors = max_errors
+
         self.x_checks = code.Hx
         self.z_checks = code.Hz
-        self.error_detection_code = error_detection_code
-        self.x_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
-        self.z_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
-        self.x_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
-        self.z_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
+        self.x_fault_sets: list[PureFaultSet] = []
+        self.z_fault_sets: list[PureFaultSet] = []
+        self.x_fault_sets_unreduced: list[PureFaultSet] = []
+        self.z_fault_sets_unreduced: list[PureFaultSet] = []
 
     def compute_fault_sets(self, reduce: bool = True) -> None:
         """Compute the fault sets for the state preparation circuit."""
-        self.compute_fault_set(self.max_errors, x_errors=True, reduce=reduce)
-        self.compute_fault_set(self.max_errors, x_errors=False, reduce=reduce)
+        self.compute_fault_set(self.max_x_errors, x_errors=True, reduce=reduce)
+        self.compute_fault_set(self.max_z_errors, x_errors=False, reduce=reduce)
 
     def compute_fault_set(self, num_errors: int = 1, x_errors: bool = True, reduce: bool = True) -> PureFaultSet:
         """Compute the fault set of the state.
@@ -89,8 +89,12 @@ class StatePrepCircuit:
         """
         fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
         fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
-        if fault_sets[num_errors] is not None:
-            return fault_sets[num_errors]  # Return cached value
+        if len(fault_sets) >= num_errors:
+            return fault_sets[num_errors - 1]  # return cached value
+
+        if num_errors <= 0:
+            msg = "Cannot compute fault set for less than 1 error."
+            raise ValueError(msg)
 
         if num_errors == 1:
             logger.info("Computing fault set for 1 error.")
@@ -98,67 +102,82 @@ class StatePrepCircuit:
         else:
             logger.info(f"Computing fault set for {num_errors} errors.")
             self.compute_fault_set(num_errors - 1, x_errors, reduce=reduce)
-            faults = fault_sets[num_errors - 1]
-            single_faults = fault_sets_unreduced[1]
-
-            assert faults is not None
-            assert single_faults is not None
+            faults = fault_sets[num_errors - 2]
+            single_faults = fault_sets_unreduced[0]
 
             fs = product_fault_set(faults, single_faults)
             fs.remove_zero_rows()
             fs.remove_duplicates()
 
-        fault_sets_unreduced[num_errors] = fs.copy()
+        fault_sets_unreduced.append(fs.copy())
 
         # reduce faults by stabilizer
         stabs = self.x_checks if x_errors else self.z_checks
 
         if reduce:
             logger.info("Removing stabilizer equivalent faults.")
-            fs.normalize(stabs)
+            fs.remove_equivalent(stabs)
 
         logger.info("Removing low-weight faults.")
         fs.filter_by_weight_at_least(num_errors + 1, stabs)
-        fault_sets[num_errors] = fs
+        fault_sets.append(fs)
 
         return fs
 
+    def set_max_errors(self, max_errors: int | tuple[int, int]) -> None:
+        """Set maximum errors. Also resets cached fault sets."""
+        if isinstance(max_errors, int):
+            self.max_x_errors = max_errors
+            self.max_z_errors = max_errors
+        else:
+            self.max_x_errors, self.max_z_errors = max_errors
+
+        # self.x_fault_sets =
+        # self.z_fault_sets =
+        # self.x_fault_sets_unreduced = [None for i in range(self.max_x_errors + 1)]
+        # self.z_fault_sets_unreduced = [None for i in range(self.max_z_errors + 1)]
+
     def combine_faults(
-        self, additional_faults: PureFaultSet, x_errors: bool = True, reduce=False
-    ) -> list[PureFaultSet | None]:
+        self, additional_faults: PureFaultSet, x_errors: bool = True, reduce: bool = False
+    ) -> list[PureFaultSet]:
         """Combine fault sets of circuit with additional independent faults.
 
         Args:
             additional_faults: The additional faults to combine with the fault set of the circuit.
             x_errors: If True, combine the fault sets for X errors. If False, combine the fault sets for Z errors.
+            reduce: If True, stabilizer-equivalent errors will be removed after fault set construction.
         """
         self.compute_fault_sets()
         fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
         fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
         stabs = self.x_checks if x_errors else self.z_checks
+        max_errors = self.max_x_errors if x_errors else self.max_z_errors
 
         if len(additional_faults) == 0:
             return fault_sets
 
-        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors + 1)]
-        new_products[1] = additional_faults
-        for i in range(2, self.max_errors):
-            new_products[i] = product_fault_set(new_products[1], new_products[i - 1])
+        new_products: list[PureFaultSet] = []
+        new_products.append(additional_faults)
+        for i in range(1, max_errors):
+            single_faults = new_products[0]
+            last_faults = new_products[i - 1]
+            new_products.append(product_fault_set(single_faults, last_faults))
 
-        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors + 1)]
-        new_fault_sets = [None for _ in range(self.max_errors + 1)]
-        for i in range(1, self.max_errors + 1):
-            fs = fault_sets_unreduced[i].copy()
+        new_fault_sets_unreduced: list[PureFaultSet] = []
+        new_fault_sets = []
+        for i in range(max_errors):
+            fs_opt = fault_sets_unreduced[i]
+            fs = fs_opt.copy()
             fs.combine(new_products[i])
-            for j in range(2, i):
+            for j in range(1, i):
                 k = i - j
                 prod = product_fault_set(new_products[j], new_products[k])
                 fs.combine(prod)
-            new_fault_sets_unreduced[i] = fs.copy()
+            new_fault_sets_unreduced.append(fs.copy())
             if reduce:
-                fs.normalize(stabs)
-            fs.filter_by_weight_at_least(i + 1, stabs)
-            new_fault_sets[i] = fs
+                fs.remove_equivalent(stabs)
+            fs.filter_by_weight_at_least(i + 2, stabs)
+            new_fault_sets.append(fs)
 
         return new_fault_sets
 
@@ -277,19 +296,17 @@ def gate_optimal_verification_stabilizers(
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
-    additional_faults: npt.NDArray[np.int8] | None = None,
 ) -> list[list[npt.NDArray[np.int8]]]:
-    """Return verification stabilizers for the state preparation circuit.
+    """Return verification stabilizers for the given fault sets..
 
     The method uses an iterative search to find the optimal set of stabilizers by repeatedly computing the optimal circuit for each number of ancillas and cnots. This is repeated for each number of independent correctable errors in the state preparation circuit. Thus the verification circuit is constructed of multiple "layers" of stabilizers, each layer corresponding to a fault set it verifies.
 
     Args:
-        sp_circ: The state preparation circuit to verify.
-        x_errors: If True, verify the X errors. If False, verify the Z errors.
+        fault_sets: List of fault sets to verify.
+        stabs: The stabilizer generators to verify the fault sets.
         min_timeout: The minimum time to allow each search to run for.
         max_timeout: The maximum time to allow each search to run for.
         max_ancillas: The maximum number of ancillas to allow in each layer verification circuit.
-        additional_faults: Faults to verify in addition to the faults propagating in the state preparation circuit.
 
     Returns:
         A list of stabilizers for each number of errors to verify the state preparation circuit.
@@ -315,13 +332,13 @@ def all_gate_optimal_verification_stabilizers(
     max_ancillas: int | None = None,
     return_all_solutions: bool = False,
 ) -> list[list[list[npt.NDArray[np.int8]]]]:
-    """Return all equivalent verification stabilizers for the state preparation circuit.
+    """Return all equivalent verification stabilizers for the given fault sets.
 
     The method uses an iterative search to find the optimal set of stabilizers by repeatedly computing the optimal circuit for each number of ancillas and cnots. This is repeated for each number of independent correctable errors in the state preparation circuit. Thus the verification circuit is constructed of multiple "layers" of stabilizers, each layer corresponding to a fault set it verifies.
 
     Args:
-        sp_circ: The state preparation circuit to verify.
-        x_errors: If True, verify the X errors. If False, verify the Z errors.
+        fault_sets: List of fault sets to verify.
+        stabs: The stabilizer generators to verify the fault sets.
         min_timeout: The minimum time to allow each search to run for.
         max_timeout: The maximum time to allow each search to run for.
         max_ancillas: The maximum number of ancillas to allow in each layer verification circuit.
@@ -432,31 +449,37 @@ def all_gate_optimal_verification_stabilizers(
 def _verification_circuit(
     sp_circ: StatePrepCircuit,
     verification_stabs_fun: Callable[[list[PureFaultSet], npt.NDArray[np.int8]], list[list[npt.NDArray[np.int8]]]],
+    only_first_layer: bool = True,
     verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     logger.info("Finding verification stabilizers for the state preparation circuit")
 
+    sp_circ.compute_fault_sets(reduce=True)
     if verify_x_first:
-        first_fault_sets = sp_circ.x_fault_sets[1:]
+        first_fault_sets = sp_circ.x_fault_sets
         first_checks = sp_circ.z_checks
-        second_fault_sets = sp_circ.z_fault_sets[1:]
-        second_checks = sp_circ.x_checks
+        if not only_first_layer:
+            second_fault_sets = sp_circ.z_fault_sets
+            second_checks = sp_circ.x_checks
     else:
-        first_fault_sets = sp_circ.z_fault_sets[1:]
+        first_fault_sets = sp_circ.z_fault_sets
         first_checks = sp_circ.x_checks
-        second_fault_sets = sp_circ.x_fault_sets[1:]
-        second_checks = sp_circ.z_checks
+        if not only_first_layer:
+            second_fault_sets = sp_circ.x_fault_sets
+            second_checks = sp_circ.z_checks
 
     layers_1 = verification_stabs_fun(first_fault_sets, first_checks)
     measurements_1 = [measurement for layer in layers_1 for measurement in layer]
     if not flag_first_layer:
         additional_errors = get_hook_errors(measurements_1)
         extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors=not verify_x_first)
-        layers_2 = verification_stabs_fun(extended_fault_sets[1:], second_checks)
-    else:
+        if not only_first_layer:
+            layers_2 = verification_stabs_fun(extended_fault_sets, second_checks)
+    elif not only_first_layer:
         layers_2 = verification_stabs_fun(second_fault_sets, second_checks)
-    measurements_2 = [measurement for layer in layers_2 for measurement in layer]
+
+    measurements_2 = [measurement for layer in layers_2 for measurement in layer] if not only_first_layer else []
 
     z_measurements = measurements_1 if verify_x_first else measurements_2
     x_measurements = measurements_2 if verify_x_first else measurements_1
@@ -474,6 +497,7 @@ def gate_optimal_verification_circuit(
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
+    only_first_layer: bool = False,
     verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
@@ -488,8 +512,12 @@ def gate_optimal_verification_circuit(
         min_timeout: The minimum time to allow each search to run for.
         max_timeout: The maximum time to allow each search to run for.
         max_ancillas: The maximum number of ancillas to allow in each layer verification circuit.
-        full_fault_tolerance: If True, the verification circuit will be constructed to be fault tolerant to all errors in the state preparation circuit. If False, the verification circuit will be constructed to be fault tolerant only to the type of errors that can cause a logical error. For a logical \|0> state preparation circuit, this means the verification circuit will be fault tolerant to X errors but not for Z errors. For a logical \|+> state preparation circuit, this means the verification circuit will be fault tolerant to Z errors but not for X errors.
+        only_first_layer: If True, only the first error type will be verified. The type depends on the `verify_x_first` argument.
+        verify_x_first: If True, X-errors are verified first.
         flag_first_layer: If True, the first verification layer (verifying X or Z errors) will also be flagged. If False, the potential hook errors introduced by the first layer will be caught by the second layer. This is only relevant if full_fault_tolerance is True.
+
+    Returns:
+        QuantumCircuit combining the state preparation and verification circuit.
     """
 
     def verification_stabs_fun(
@@ -498,7 +526,11 @@ def gate_optimal_verification_circuit(
         return gate_optimal_verification_stabilizers(fault_sets, stabs, min_timeout, max_timeout, max_ancillas)
 
     return _verification_circuit(
-        sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
+        sp_circ,
+        verification_stabs_fun,
+        only_first_layer=only_first_layer,
+        verify_x_first=verify_x_first,
+        flag_first_layer=flag_first_layer,
     )
 
 
@@ -506,6 +538,7 @@ def heuristic_verification_circuit(
     sp_circ: StatePrepCircuit,
     max_covering_sets: int = 10000,
     find_coset_leaders: bool = True,
+    only_first_layer: bool = False,
     verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
@@ -517,8 +550,12 @@ def heuristic_verification_circuit(
         sp_circ: The state preparation circuit to verify.
         max_covering_sets: The maximum number of covering sets to consider.
         find_coset_leaders: Whether to find coset leaders for the found measurements. This is done using SAT solvers so it can be slow.
-        full_fault_tolerance: If True, the verification circuit will be constructed to be fault tolerant to all errors in the state preparation circuit. If False, the verification circuit will be constructed to be fault tolerant only to the type of errors that can cause a logical error. For a logical \|0> state preparation circuit, this means the verification circuit will be fault tolerant to X errors but not for Z errors. For a logical \|+> state preparation circuit, this means the verification circuit will be fault tolerant to Z errors but not for X errors.
+        only_first_layer: If True, only the first error type will be verified. The type depends on the `verify_x_first` argument.
+        verify_x_first: If True, X-errors are verified first.
         flag_first_layer: If True, the first verification layer (verifying X or Z errors) will also be flagged. If False, the potential hook errors introduced by the first layer will be caught by the second layer. This is only relevant if full_fault_tolerance is True.
+
+    Returns:
+        QuantumCircuit combining the state preparation and verification circuit.
     """
 
     def verification_stabs_fun(
@@ -527,7 +564,11 @@ def heuristic_verification_circuit(
         return heuristic_verification_stabilizers(fault_sets, stabs, max_covering_sets, find_coset_leaders)
 
     return _verification_circuit(
-        sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
+        sp_circ,
+        verification_stabs_fun,
+        only_first_layer=only_first_layer,
+        verify_x_first=verify_x_first,
+        flag_first_layer=flag_first_layer,
     )
 
 
@@ -536,23 +577,21 @@ def heuristic_verification_stabilizers(
     stabs: npt.NDArray[np.int8],
     max_covering_sets: int = 10000,
     find_coset_leaders: bool = True,
-    additional_faults: npt.NDArray[np.int8] | None = None,
 ) -> list[list[npt.NDArray[np.int8]]]:
-    """Return verification stabilizers for the preparation circuit.
+    """Return verification stabilizers for the given fault sets.
 
     Args:
-        sp_circ: The state preparation circuit to verify.
-        x_errors: Whether to find verification stabilizers for X errors. If False, find for Z errors.
+        fault_sets: List of fault sets to verify.
+        stabs: The stabilizer generators to verify the fault sets.
         max_covering_sets: The maximum number of covering sets to consider.
         find_coset_leaders: Whether to find coset leaders for the found measurements. This is done using SAT solvers so it can be slow.
-        additional_faults: Faults to verify in addition to the faults propagating in the state preparation circuit.
     """
     logger.info("Finding verification stabilizers using heuristic method")
     n_layers = len(fault_sets)
     layers: list[list[npt.NDArray[np.int8]]] = [[] for _ in range(n_layers)]
 
     for num_errors in range(n_layers):
-        logger.info(f"Finding verification stabilizers for {num_errors} errors")
+        logger.info(f"Finding verification stabilizers for {num_errors + 1} errors")
         faults = fault_sets[num_errors]
         assert faults is not None
         logger.info(f"There are {len(faults)} faults")
@@ -719,12 +758,12 @@ def _measure_ft_stabs(
     measured_circ.compose(sp_circ.circ.to_qiskit_circuit(), inplace=True)
 
     if verify_x_first:
-        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_errors, flags=flag_first_layer)
-        _measure_ft_x(measured_circ, x_measurements, flags=True, t=sp_circ.max_errors)
+        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_z_errors, flags=flag_first_layer)
+        _measure_ft_x(measured_circ, x_measurements, flags=True, t=sp_circ.max_x_errors)
 
     else:
-        _measure_ft_x(measured_circ, x_measurements, flags=flag_first_layer, t=sp_circ.max_errors)
-        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_errors)
+        _measure_ft_x(measured_circ, x_measurements, flags=flag_first_layer, t=sp_circ.max_x_errors)
+        _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_z_errors)
 
     return measured_circ
 
@@ -735,14 +774,16 @@ def verification_stabilizers(
     num_anc: int,
     num_cnots: int,
 ) -> list[npt.NDArray[np.int8]] | None:
-    """Return a verification stabilizers for num_errors independent errors in the state preparation circuit using z3.
+    """Return a set of stabilizers detecting all errors in `fault_set` using at most `num_anc` ancillas and at most `num_cnots` cnots.
 
     Args:
-        sp_circ: The state preparation circuit.
-        fault_set: The set of errors to verify.
+        fault_set: The fault set to verify.
+        stabs: The stabilizer generators to verify the fault set.
         num_anc: The maximum number of ancilla qubits to use.
         num_cnots: The maximum number of CNOT gates to use.
-        x_errors: If True, the errors are X errors. Otherwise, the errors are Z errors.
+
+    Returns:
+        List of stabilizers.
     """
     stabs_list = all_verification_stabilizers(fault_set, stabs, num_anc, num_cnots, return_all_solutions=False)
     if stabs_list:
@@ -819,86 +860,18 @@ def all_verification_stabilizers(
     return None
 
 
-def _propagate_error(nodes: list[DAGNode], n_qubits: int, x_errors: bool = True) -> PauliList:
-    """Propagates a Pauli error through a circuit beginning from first node.
-
-    Args:
-        nodes: List of nodes in the circuit in topological order.
-        n_qubits: Number of qubits in the circuit.
-        x_errors: If True, propagate X errors. Otherwise, propagate Z errors.
-    """
-    start = nodes[0]
-    error: npt.NDArray[np.int8] = np.array([0] * n_qubits, dtype=np.int8)
-    error[start.qargs[0]._index] = 1  # noqa: SLF001
-    error[start.qargs[1]._index] = 1  # noqa: SLF001
-    # propagate error through circuit via bfs
-    for node in nodes[1:]:
-        control = node.qargs[0]._index  # noqa: SLF001
-        target = node.qargs[1]._index  # noqa: SLF001
-        if x_errors:
-            error[target] = (error[target] + error[control]) % 2
-        else:
-            error[control] = (error[target] + error[control]) % 2
-    return error
-
-
-def _remove_trivial_faults(
-    faults: npt.NDArray[np.int8], stabs: npt.NDArray[np.int8], num_errors: int
-) -> npt.NDArray[np.int8]:
-    faults = faults.copy()
-    logger.info("Removing trivial faults.")
-    max_w = 1
-    for i, fault in enumerate(faults):
-        faults[i] = coset_leader(fault, stabs)
-    faults = faults[np.where(np.sum(faults, axis=1) > max_w * num_errors)[0]]
-
-    # unique faults
-    return np.unique(faults, axis=0)
-
-
-def _remove_stabilizer_equivalent_faults(
-    faults: npt.NDArray[np.int8], stabilizers: npt.NDArray[np.int8]
-) -> npt.NDArray[np.int8]:
-    """Remove stabilizer equivalent faults from a list of faults."""
-    faults = faults.copy()
-    stabilizers = stabilizers.copy()
-    removed = set()
-
-    logger.debug(f"Removing stabilizer equivalent faults from {len(faults)} faults.")
-    for i, f1 in enumerate(faults):
-        if i in removed:
-            continue
-        stabs_ext1 = np.vstack((stabilizers, f1))
-        if mod2.rank(stabs_ext1) == mod2.rank(stabilizers):
-            removed.add(i)
-            continue
-
-        for j, f2 in enumerate(faults[i + 1 :]):
-            if j + i + 1 in removed:
-                continue
-            stabs_ext2 = np.vstack((stabs_ext1, f2))
-
-            if mod2.rank(stabs_ext2) == mod2.rank(stabs_ext1):
-                removed.add(j + i + 1)
-
-    logger.debug(f"Removed {len(removed)} stabilizer equivalent faults.")
-    indices = list(set(range(len(faults))) - removed)
-    if len(indices) == 0:
-        return np.array([])
-
-    return faults[indices]
-
-
 def naive_verification_circuit(sp_circ: StatePrepCircuit, flag_first_layer: bool = True) -> QuantumCircuit:
     """Naive verification circuit for a state preparation circuit."""
-    if sp_circ.code.Hx is None or sp_circ.code.Hz is None:
-        msg = "Code must have stabilizers defined."
-        raise ValueError(msg)
+    code = sp_circ.circ.get_code()
 
-    z_measurements = list(sp_circ.code.Hx)
-    x_measurements = list(sp_circ.code.Hz)
-    reps = sp_circ.max_errors
-    return _measure_ft_stabs(sp_circ, z_measurements * reps, x_measurements * reps, flag_first_layer=flag_first_layer)
+    z_measurements = code.Hz
+    x_measurements = code.Hx
+    return _measure_ft_stabs(
+        sp_circ,
+        z_measurements * sp_circ.max_z_errors,
+        x_measurements * sp_circ.max_x_errors,
+        flag_first_layer=flag_first_layer,
+    )
 
 
 def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> PureFaultSet:

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -17,12 +17,11 @@ import numpy as np
 import z3
 from ldpc import mod2
 from qiskit.circuit import AncillaRegister, ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.converters import circuit_to_dag
 
 from ..codes import InvalidCSSCodeError
-from .faults import coset_leader, PureFaultSet
+from .circuits import CNOTCircuit
+from .faults import PureFaultSet, coset_leader, product_fault_set
 from .synthesis_utils import (
-    build_css_circuit_from_cnot_list,
     heuristic_gaussian_elimination,
     iterative_search_with_timeout,
     measure_flagged,
@@ -31,8 +30,7 @@ from .synthesis_utils import (
     run_with_timeout,
     vars_to_stab,
 )
-from .circuits import CNOTCircuit
-from .faults import PureFaultSet, product_fault_set
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -48,9 +46,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class StatePrepCircuit:
     """Represents a state preparation circuit for a CSS code."""
 
-    def __init__(
-            self, circ: CNOTCircuit, max_errors:int, error_detection_code: bool = False
-    ) -> None:
+    def __init__(self, circ: CNOTCircuit, max_errors: int, error_detection_code: bool = False) -> None:
         """Initialize a state preparation circuit.
 
         Args:
@@ -60,8 +56,9 @@ class StatePrepCircuit:
             error_detection_code: If True, prepare the state for error detection. This ensures that when computing the fault set of the circuit, up to d//2 errors errors can occur in the circuit.
         """
         if not circ.is_state():
-            raise ValueError("Input circuit is not a state!")
-        
+            msg = "Input circuit is not a state!"
+            raise ValueError(msg)
+
         self.circ = circ
         code = circ.get_code()
         self.num_qubits = circ.num_qubits()
@@ -69,20 +66,17 @@ class StatePrepCircuit:
         self.x_checks = code.Hx
         self.z_checks = code.Hz
         self.error_detection_code = error_detection_code
-        self.x_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
-        self.z_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
-        self.x_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
-        self.z_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
+        self.x_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
+        self.z_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
+        self.x_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
+        self.z_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors + 1)]
 
-        
     def compute_fault_sets(self, reduce: bool = True) -> None:
         """Compute the fault sets for the state preparation circuit."""
         self.compute_fault_set(self.max_errors, x_errors=True, reduce=reduce)
         self.compute_fault_set(self.max_errors, x_errors=False, reduce=reduce)
 
-    def compute_fault_set(
-        self, num_errors: int = 1, x_errors: bool = True, reduce: bool = True
-    ) -> PureFaultSet:
+    def compute_fault_set(self, num_errors: int = 1, x_errors: bool = True, reduce: bool = True) -> PureFaultSet:
         """Compute the fault set of the state.
 
         Args:
@@ -95,7 +89,7 @@ class StatePrepCircuit:
         """
         fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
         fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
-        if fault_sets[num_errors] is not None: 
+        if fault_sets[num_errors] is not None:
             return fault_sets[num_errors]  # Return cached value
 
         if num_errors == 1:
@@ -109,7 +103,7 @@ class StatePrepCircuit:
 
             assert faults is not None
             assert single_faults is not None
-            
+
             fs = product_fault_set(faults, single_faults)
             fs.remove_zero_rows()
             fs.remove_duplicates()
@@ -123,14 +117,14 @@ class StatePrepCircuit:
             logger.info("Removing stabilizer equivalent faults.")
             fs.normalize(stabs)
 
-        logger.info("Removing low-weight faults.")            
-        fs.filter_by_weight_at_least(num_errors+1, stabs)
+        logger.info("Removing low-weight faults.")
+        fs.filter_by_weight_at_least(num_errors + 1, stabs)
         fault_sets[num_errors] = fs
 
         return fs
 
     def combine_faults(
-            self, additional_faults: PureFaultSet, x_errors: bool = True, reduce=False
+        self, additional_faults: PureFaultSet, x_errors: bool = True, reduce=False
     ) -> list[PureFaultSet | None]:
         """Combine fault sets of circuit with additional independent faults.
 
@@ -142,18 +136,18 @@ class StatePrepCircuit:
         fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
         fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
         stabs = self.x_checks if x_errors else self.z_checks
-        
+
         if len(additional_faults) == 0:
             return fault_sets
 
-        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors+1)]
+        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors + 1)]
         new_products[1] = additional_faults
         for i in range(2, self.max_errors):
-            new_products[i] = product_fault_set(new_products[1], new_products[i-1])
+            new_products[i] = product_fault_set(new_products[1], new_products[i - 1])
 
-        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors+1)]
-        new_fault_sets = [None for _ in range(self.max_errors+1)]
-        for i in range(1, self.max_errors+1):
+        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors + 1)]
+        new_fault_sets = [None for _ in range(self.max_errors + 1)]
+        for i in range(1, self.max_errors + 1):
             fs = fault_sets_unreduced[i].copy()
             fs.combine(new_products[i])
             for j in range(2, i):
@@ -165,7 +159,6 @@ class StatePrepCircuit:
                 fs.normalize(stabs)
             fs.filter_by_weight_at_least(i + 1, stabs)
             new_fault_sets[i] = fs
-
 
         return new_fault_sets
 
@@ -201,7 +194,7 @@ def heuristic_prep_circuit(code: CSSCode, optimize_depth: bool = True, zero_stat
     checks, cnots = heuristic_gaussian_elimination(checks, parallel_elimination=optimize_depth)
 
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, max_errors=code.distance//2)
+    return StatePrepCircuit(circ, max_errors=code.distance // 2)
 
 
 def depth_optimal_prep_circuit(
@@ -238,7 +231,7 @@ def depth_optimal_prep_circuit(
         return None
     checks, cnots = res
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, code.distance//2)
+    return StatePrepCircuit(circ, code.distance // 2)
 
 
 def gate_optimal_prep_circuit(
@@ -275,7 +268,7 @@ def gate_optimal_prep_circuit(
         return None
     checks, cnots = res
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, code.distance//2)
+    return StatePrepCircuit(circ, code.distance // 2)
 
 
 def gate_optimal_verification_stabilizers(
@@ -346,7 +339,7 @@ def all_gate_optimal_verification_stabilizers(
     for layer in range(n_layers):
         logger.info(f"Finding verification stabilizers for {layer} errors")
         faults = fault_sets[layer]
-        
+
         if len(faults) == 0:
             logger.info(f"No non-trivial faults for {layer} errors")
             layers[layer] = []
@@ -358,7 +351,7 @@ def all_gate_optimal_verification_stabilizers(
         max_cnots: int = np.sum(stabs)
 
         logger.info(
-            f"Finding verification stabilizers for {layer+1} errors with {min_cnots} to {max_cnots} CNOTs using {num_anc} ancillas"
+            f"Finding verification stabilizers for {layer + 1} errors with {min_cnots} to {max_cnots} CNOTs using {num_anc} ancillas"
         )
 
         def fun(num_cnots: int) -> list[npt.NDArray[np.int8]] | None:
@@ -378,15 +371,15 @@ def all_gate_optimal_verification_stabilizers(
             measurements = None
 
         if measurements is None:
-            logger.info(f"No verification stabilizers found for {layer+1} errors")
+            logger.info(f"No verification stabilizers found for {layer + 1} errors")
             return []  # No solution found
 
-        logger.info(f"Found verification stabilizers for {layer+1} errors with {num_cnots} CNOTs")
+        logger.info(f"Found verification stabilizers for {layer + 1} errors with {num_cnots} CNOTs")
         # If any measurements are unused we can reduce the number of ancillas at least by that
         measurements = [m for m in measurements if np.any(m)]
         num_anc = len(measurements)
         # Iterate backwards to find the minimal number of cnots
-        logger.info(f"Finding minimal number of CNOTs for {layer+1} errors")
+        logger.info(f"Finding minimal number of CNOTs for {layer + 1} errors")
 
         def search_cnots(num_cnots: int) -> list[npt.NDArray[np.int8]] | None:
             return verification_stabilizers(faults, stabs, num_anc, num_cnots)  # noqa: B023
@@ -407,7 +400,7 @@ def all_gate_optimal_verification_stabilizers(
         logger.info(f"Minimal number of CNOTs for {layer} errors is: {num_cnots}")
 
         # If the number of CNOTs is minimal, we can reduce the number of ancillas
-        logger.info(f"Finding minimal number of ancillas for {layer+1} errors")
+        logger.info(f"Finding minimal number of ancillas for {layer + 1} errors")
         while num_anc - 1 > 0:
             logger.info(f"Trying {num_anc - 1} ancillas")
 
@@ -424,13 +417,11 @@ def all_gate_optimal_verification_stabilizers(
                 measurements = anc_opt
             else:
                 break
-        logger.info(f"Minimal number of ancillas for {layer+1} errors is: {num_anc}")
+        logger.info(f"Minimal number of ancillas for {layer + 1} errors is: {num_anc}")
         if not return_all_solutions:
-            layers[layer - 1] = [measurements]
+            layers[layer] = [measurements]
         else:
-            all_stabs = all_verification_stabilizers(
-                faults, stabs, num_anc, num_cnots, return_all_solutions=True
-            )
+            all_stabs = all_verification_stabilizers(faults, stabs, num_anc, num_cnots, return_all_solutions=True)
             if all_stabs:
                 layers[layer] = all_stabs
                 logger.info(f"Found {len(layers[layer])} equivalent solutions for {layer} errors")
@@ -440,9 +431,7 @@ def all_gate_optimal_verification_stabilizers(
 
 def _verification_circuit(
     sp_circ: StatePrepCircuit,
-    verification_stabs_fun: Callable[
-        [list[PureFaultSet], npt.NDArray[np.int8]], list[list[npt.NDArray[np.int8]]]
-    ],
+    verification_stabs_fun: Callable[[list[PureFaultSet], npt.NDArray[np.int8]], list[list[npt.NDArray[np.int8]]]],
     verify_x_first: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
@@ -460,10 +449,10 @@ def _verification_circuit(
         second_checks = sp_circ.z_checks
 
     layers_1 = verification_stabs_fun(first_fault_sets, first_checks)
-    measurements_1 = [measurement for layer in layers_1 for measurement in layer]        
+    measurements_1 = [measurement for layer in layers_1 for measurement in layer]
     if not flag_first_layer:
         additional_errors = get_hook_errors(measurements_1)
-        extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors= not verify_x_first)
+        extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors=not verify_x_first)
         layers_2 = verification_stabs_fun(extended_fault_sets[1:], second_checks)
     else:
         layers_2 = verification_stabs_fun(second_fault_sets, second_checks)
@@ -506,9 +495,7 @@ def gate_optimal_verification_circuit(
     def verification_stabs_fun(
         fault_sets: list[PureFaultSet], stabs: npt.NDArray[np.int8]
     ) -> list[list[npt.NDArray[np.int8]]]:
-        return gate_optimal_verification_stabilizers(
-            fault_sets, stabs, min_timeout, max_timeout, max_ancillas
-        )
+        return gate_optimal_verification_stabilizers(fault_sets, stabs, min_timeout, max_timeout, max_ancillas)
 
     return _verification_circuit(
         sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
@@ -537,9 +524,7 @@ def heuristic_verification_circuit(
     def verification_stabs_fun(
         fault_sets: list[PureFaultSet], stabs: npt.NDArray[np.int8]
     ) -> list[list[npt.NDArray[np.int8]]]:
-        return heuristic_verification_stabilizers(
-            fault_sets, stabs, max_covering_sets, find_coset_leaders
-        )
+        return heuristic_verification_stabilizers(fault_sets, stabs, max_covering_sets, find_coset_leaders)
 
     return _verification_circuit(
         sp_circ, verification_stabs_fun, verify_x_first=verify_x_first, flag_first_layer=flag_first_layer
@@ -566,7 +551,7 @@ def heuristic_verification_stabilizers(
     n_layers = len(fault_sets)
     layers: list[list[npt.NDArray[np.int8]]] = [[] for _ in range(n_layers)]
 
-    for num_errors in range(0, n_layers):
+    for num_errors in range(n_layers):
         logger.info(f"Finding verification stabilizers for {num_errors} errors")
         faults = fault_sets[num_errors]
         assert faults is not None
@@ -740,7 +725,6 @@ def _measure_ft_stabs(
     else:
         _measure_ft_x(measured_circ, x_measurements, flags=flag_first_layer, t=sp_circ.max_errors)
         _measure_ft_z(measured_circ, z_measurements, t=sp_circ.max_errors)
-    
 
     return measured_circ
 
@@ -760,9 +744,7 @@ def verification_stabilizers(
         num_cnots: The maximum number of CNOT gates to use.
         x_errors: If True, the errors are X errors. Otherwise, the errors are Z errors.
     """
-    stabs_list = all_verification_stabilizers(
-        fault_set, stabs, num_anc, num_cnots, return_all_solutions=False
-    )
+    stabs_list = all_verification_stabilizers(fault_set, stabs, num_anc, num_cnots, return_all_solutions=False)
     if stabs_list:
         return stabs_list[0]
     return None
@@ -784,16 +766,17 @@ def all_verification_stabilizers(
         num_cnots: The maximum number of CNOT gates to use.
         return_all_solutions: If True, return all solutions. Otherwise, return the first solution found.
     """
-
     # Measurements are written as sums of generators
     # The variables indicate which generators are non-zero in the sum
     if fault_set.faults.shape[1] != stabs.shape[1]:
         msg = "Fault set and stabilizers must have the same number of qubits."
         raise ValueError(msg)
-    
+
     # Check if fault set can be verified, i.e., every fault can be detected by at least one measurement
-    if any(np.all(fault_set.faults@ stabs.T % 2 == 0, axis=1)):
-        logger.warning("Fault set cannot be verified by the given stabilizers. Some faults are not detectable by the given stabilizers.")
+    if any(np.all(fault_set.faults @ stabs.T % 2 == 0, axis=1)):
+        logger.warning(
+            "Fault set cannot be verified by the given stabilizers. Some faults are not detectable by the given stabilizers."
+        )
         return None
 
     n_gens = stabs.shape[0]
@@ -812,11 +795,7 @@ def all_verification_stabilizers(
     )
 
     # assert that not too many CNOTs are used
-    solver.add(
-        z3.PbLe(
-            [(measurement[q], 1) for measurement in measurement_stabs for q in range(n_qubits)], num_cnots
-        )
-    )
+    solver.add(z3.PbLe([(measurement[q], 1) for measurement in measurement_stabs for q in range(n_qubits)], num_cnots))
 
     solutions = []
     while solver.check() == z3.sat:

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -20,7 +20,7 @@ from qiskit.circuit import AncillaRegister, ClassicalRegister, QuantumCircuit, Q
 from qiskit.converters import circuit_to_dag
 
 from ..codes import InvalidCSSCodeError
-from .faults import coset_leader
+from .faults import coset_leader, PureFaultSet
 from .synthesis_utils import (
     build_css_circuit_from_cnot_list,
     heuristic_gaussian_elimination,
@@ -31,7 +31,8 @@ from .synthesis_utils import (
     run_with_timeout,
     vars_to_stab,
 )
-
+from .circuits import CNOTCircuit
+from .faults import PureFaultSet, product_fault_set
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -48,7 +49,7 @@ class StatePrepCircuit:
     """Represents a state preparation circuit for a CSS code."""
 
     def __init__(
-        self, circ: QuantumCircuit, code: CSSCode, zero_state: bool = True, error_detection_code: bool = False
+            self, circ: CNOTCircuit, max_errors:int, error_detection_code: bool = False
     ) -> None:
         """Initialize a state preparation circuit.
 
@@ -58,30 +59,22 @@ class StatePrepCircuit:
             zero_state: If True, prepare the +1 eigenstate of the Z basis. If False, prepare the +1 eigenstate of the X basis.
             error_detection_code: If True, prepare the state for error detection. This ensures that when computing the fault set of the circuit, up to d//2 errors errors can occur in the circuit.
         """
+        if not circ.is_state():
+            raise ValueError("Input circuit is not a state!")
+        
         self.circ = circ
-        self.code = code
-        self.zero_state = zero_state
-
-        if code.Hx is None or code.Hz is None:
-            msg = "The CSS code must have both X and Z checks."
-            raise InvalidCSSCodeError(msg)
-
-        self.x_checks = code.Hx.copy() if zero_state else np.vstack((code.Lx.copy(), code.Hx.copy()))
-        self.z_checks = code.Hz.copy() if not zero_state else np.vstack((code.Lz.copy(), code.Hz.copy()))
-
-        self.num_qubits = circ.num_qubits
-
+        code = circ.get_code()
+        self.num_qubits = circ.num_qubits()
+        self.max_errors = max_errors
+        self.x_checks = code.Hx
+        self.z_checks = code.Hz
         self.error_detection_code = error_detection_code
-        self._set_max_errors()
+        self.x_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
+        self.z_fault_sets: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
+        self.x_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
+        self.z_fault_sets_unreduced: list[PureFaultSet | None] = [None for i in range(max_errors+1)]
 
-        self.max_x_measurements = len(self.x_checks)
-        self.max_z_measurements = len(self.z_checks)
-
-    def set_error_detection(self, error_detection: bool) -> None:
-        """Set whether the state preparation circuit is for error detection."""
-        self.error_detection_code = error_detection
-        self._set_max_errors()
-
+        
     def compute_fault_sets(self, reduce: bool = True) -> None:
         """Compute the fault sets for the state preparation circuit."""
         self.compute_fault_set(self.max_errors, x_errors=True, reduce=reduce)
@@ -89,7 +82,7 @@ class StatePrepCircuit:
 
     def compute_fault_set(
         self, num_errors: int = 1, x_errors: bool = True, reduce: bool = True
-    ) -> npt.NDArray[np.int8]:
+    ) -> PureFaultSet:
         """Compute the fault set of the state.
 
         Args:
@@ -100,70 +93,45 @@ class StatePrepCircuit:
         Returns:
             The fault set of the state.
         """
-        faults: npt.NDArray[np.int8] | None = (
-            self.x_fault_sets[num_errors] if x_errors else self.z_fault_sets[num_errors]
-        )
-        if faults is not None:
-            return faults
+        fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
+        fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
+        if fault_sets[num_errors] is not None: 
+            return fault_sets[num_errors]  # Return cached value
 
         if num_errors == 1:
             logger.info("Computing fault set for 1 error.")
-            dag = circuit_to_dag(self.circ)
-            for node in dag.front_layer():  # remove hadamards
-                dag.remove_op_node(node)
-            fault_list = []
-            # propagate every error before a control
-            nodes = list(dag.topological_op_nodes())
-            for i in range(len(nodes)):
-                error = _propagate_error(nodes[i:], dag.num_qubits(), x_errors=x_errors)
-                fault_list.append(error)
-            faults = np.array(fault_list, dtype=np.int8)
-            faults = np.unique(faults, axis=0)
-
-            if x_errors and self.x_fault_sets_unreduced[1] is None:
-                non_propagated_single_errors = np.eye(self.num_qubits, dtype=np.int8)
-                self.x_fault_sets_unreduced[1] = np.vstack((faults, non_propagated_single_errors))
-            elif not x_errors and self.z_fault_sets[1] is None:
-                non_propagated_single_errors = np.eye(self.num_qubits, dtype=np.int8)
-                self.z_fault_sets_unreduced[1] = np.vstack((faults, non_propagated_single_errors))
+            fs = PureFaultSet.from_cnot_circuit(self.circ, kind="X" if x_errors else "Z")
         else:
             logger.info(f"Computing fault set for {num_errors} errors.")
             self.compute_fault_set(num_errors - 1, x_errors, reduce=reduce)
-            if x_errors:
-                faults = self.x_fault_sets_unreduced[num_errors - 1]
-                single_faults = self.x_fault_sets_unreduced[1]
-            else:
-                faults = self.z_fault_sets_unreduced[num_errors - 1]
-                single_faults = self.z_fault_sets_unreduced[1]
+            faults = fault_sets[num_errors - 1]
+            single_faults = fault_sets_unreduced[1]
 
             assert faults is not None
             assert single_faults is not None
+            
+            fs = product_fault_set(faults, single_faults)
+            fs.remove_zero_rows()
+            fs.remove_duplicates()
 
-            new_faults = (faults[:, np.newaxis, :] + single_faults).reshape(-1, self.num_qubits) % 2
-            # remove duplicates
-            faults = np.unique(new_faults, axis=0)
-            if x_errors:
-                self.x_fault_sets_unreduced[num_errors] = faults.copy()
-            else:
-                self.z_fault_sets_unreduced[num_errors] = faults.copy()
+            fault_sets_unreduced[num_errors] = fs.copy()
 
         # reduce faults by stabilizer
         stabs = self.x_checks if x_errors else self.z_checks
-        faults = _remove_trivial_faults(faults, stabs, num_errors)
 
-        # remove stabilizer equivalent faults
         if reduce:
             logger.info("Removing stabilizer equivalent faults.")
-            faults = _remove_stabilizer_equivalent_faults(faults, stabs)
-        if x_errors:
-            self.x_fault_sets[num_errors] = faults
-        else:
-            self.z_fault_sets[num_errors] = faults
-        return faults
+            fs.normalize(stabs)
+
+        logger.info("Removing low-weight faults.")            
+        fs.filter_by_weight_at_least(num_errors+1, stabs)
+        fault_sets[num_errors] = fs
+
+        return fs
 
     def combine_faults(
-        self, additional_faults: npt.NDArray[np.int8], x_errors: bool = True
-    ) -> list[npt.NDArray[np.int8] | None]:
+            self, additional_faults: PureFaultSet, x_errors: bool = True, reduce=False
+    ) -> list[PureFaultSet | None]:
         """Combine fault sets of circuit with additional independent faults.
 
         Args:
@@ -171,57 +139,48 @@ class StatePrepCircuit:
             x_errors: If True, combine the fault sets for X errors. If False, combine the fault sets for Z errors.
         """
         self.compute_fault_sets()
-        if len(additional_faults) == 0:
-            return self.x_fault_sets if x_errors else self.z_fault_sets
-
-        fault_sets_unreduced = self.x_fault_sets_unreduced.copy() if x_errors else self.z_fault_sets_unreduced.copy()
-        assert fault_sets_unreduced[1] is not None
-        fault_sets_unreduced[1] = np.vstack((fault_sets_unreduced[1], additional_faults))
-
-        for i in range(1, self.max_errors):
-            uncombined = fault_sets_unreduced[i]
-            assert uncombined is not None
-            combined = (uncombined[:, np.newaxis, :] + additional_faults).reshape(-1, self.num_qubits) % 2
-            next_faults = fault_sets_unreduced[i + 1]
-            assert next_faults is not None
-            fault_sets_unreduced[i + 1] = np.vstack((next_faults, combined))
-        fault_sets: list[npt.NDArray[np.int8] | None] = [None for _ in range(self.max_errors + 1)]
+        fault_sets = self.x_fault_sets if x_errors else self.z_fault_sets
+        fault_sets_unreduced = self.x_fault_sets_unreduced if x_errors else self.z_fault_sets_unreduced
         stabs = self.x_checks if x_errors else self.z_checks
-        for num_errors in range(1, self.max_errors + 1):
-            fs = fault_sets_unreduced[num_errors]
-            assert fs is not None
-            fault_sets[num_errors] = _remove_trivial_faults(fs, stabs, num_errors)
-        return fault_sets
+        
+        if len(additional_faults) == 0:
+            return fault_sets
 
-    def _set_max_errors(self) -> None:
-        if self.code.distance == 2:
-            logger.warning("Code distance is 2, assuming error detection code.")
-            self.error_detection_code = True
+        new_products: list[PureFaultSet | None] = [None for _ in range(self.max_errors)]
+        new_products[1] = additional_faults
+        for i in range(2, self.max_errors):
+            new_products[i] = product_fault_set(new_products[1], new_products[i-1])
 
-        self.max_errors = (self.code.distance - 1) // 2 if not self.error_detection_code else self.code.distance // 2
-        self.max_x_errors = (
-            (self.code.x_distance - 1) // 2 if not self.error_detection_code else self.code.x_distance // 2
-        )
-        self.max_z_errors = (
-            (self.code.z_distance - 1) // 2 if not self.error_detection_code else self.code.z_distance // 2
-        )
-        self.x_fault_sets: list[npt.NDArray[np.int8] | None] = [None for _ in range(self.max_errors + 1)]
-        self.z_fault_sets: list[npt.NDArray[np.int8] | None] = [None for _ in range(self.max_errors + 1)]
-        self.x_fault_sets_unreduced: list[npt.NDArray[np.int8] | None] = [None for _ in range(self.max_errors + 1)]
-        self.z_fault_sets_unreduced: list[npt.NDArray[np.int8] | None] = [None for _ in range(self.max_errors + 1)]
+        new_fault_sets_unreduced: list[PureFaultSet | None] = [None for _ in range(self.max_errors)+1]
+        new_fault_sets = [None for _ in range(self.max_errors)+1]
+        for i in range(1, self.max_errors):
+            fs = fault_sets_unreduced[i].copy()
+            fs.combine(new_products[i])
+            for j in range(1, i):
+                k = i - j
+                prod = product_fault_set(new_products[j], new_products[k])
+                fs.combine(prod)
+            new_fault_sets_unreduced[i] = fs.copy()
+            if reduce:
+                fs.normalize(stabs)
+            fs.filter_by_weight_at_least(i + 1, stabs)
+            new_fault_sets[i] = fs
+
+
+        return new_fault_sets
 
 
 def _build_state_prep_circuit_from_back(
     checks: npt.NDArray[np.int8], cnots: list[tuple[int, int]], zero_state: bool = True
-) -> QuantumCircuit:
+) -> CNOTCircuit:
     cnots.reverse()
     if zero_state:
         hadamards = np.where(np.sum(checks, axis=0) != 0)[0]
     else:
         hadamards = np.where(np.sum(checks, axis=0) == 0)[0]
         cnots = [(j, i) for i, j in cnots]
-
-    return build_css_circuit_from_cnot_list(checks.shape[1], cnots, list(hadamards))
+    non_hadamards = [i for i in range(checks.shape[1]) if i not in hadamards]
+    return CNOTCircuit.from_cnot_list(cnots, initialize_z=non_hadamards, initialize_x=hadamards)
 
 
 def heuristic_prep_circuit(code: CSSCode, optimize_depth: bool = True, zero_state: bool = True) -> StatePrepCircuit:
@@ -242,7 +201,7 @@ def heuristic_prep_circuit(code: CSSCode, optimize_depth: bool = True, zero_stat
     checks, cnots = heuristic_gaussian_elimination(checks, parallel_elimination=optimize_depth)
 
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, code, zero_state)
+    return StatePrepCircuit(circ, max_errors=code.distance//2)
 
 
 def depth_optimal_prep_circuit(
@@ -279,7 +238,7 @@ def depth_optimal_prep_circuit(
         return None
     checks, cnots = res
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, code, zero_state)
+    return StatePrepCircuit(circ, code.distance//2)
 
 
 def gate_optimal_prep_circuit(
@@ -316,12 +275,12 @@ def gate_optimal_prep_circuit(
         return None
     checks, cnots = res
     circ = _build_state_prep_circuit_from_back(checks, cnots, zero_state)
-    return StatePrepCircuit(circ, code, zero_state)
+    return StatePrepCircuit(circ, code.distance//2)
 
 
 def gate_optimal_verification_stabilizers(
-    sp_circ: StatePrepCircuit,
-    x_errors: bool = True,
+    fault_sets: list[PureFaultSet],
+    stabs: npt.NDArray[np.int8],
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
@@ -343,26 +302,24 @@ def gate_optimal_verification_stabilizers(
         A list of stabilizers for each number of errors to verify the state preparation circuit.
     """
     return [
-        stabs[0] if stabs != [] else []
-        for stabs in all_gate_optimal_verification_stabilizers(
-            sp_circ,
-            x_errors,
+        layers[0] if layers != [] else []
+        for layers in all_gate_optimal_verification_stabilizers(
+            fault_sets,
+            stabs,
             min_timeout,
             max_timeout,
             max_ancillas,
-            additional_faults,
             return_all_solutions=False,
         )
     ]
 
 
 def all_gate_optimal_verification_stabilizers(
-    sp_circ: StatePrepCircuit,
-    x_errors: bool = True,
+    fault_sets: list[PureFaultSet],
+    stabs: npt.NDArray[np.int8],
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
-    additional_faults: npt.NDArray[np.int8] | None = None,
     return_all_solutions: bool = False,
 ) -> list[list[list[npt.NDArray[np.int8]]]]:
     """Return all equivalent verification stabilizers for the state preparation circuit.
@@ -381,43 +338,31 @@ def all_gate_optimal_verification_stabilizers(
     Returns:
         A list of all equivalent stabilizers for each number of errors to verify the state preparation circuit.
     """
-    max_errors = sp_circ.max_errors
-    layers: list[list[list[npt.NDArray[np.int8]]]] = [[] for _ in range(max_errors)]
-    if max_ancillas is None:
-        max_ancillas = sp_circ.max_z_measurements if x_errors else sp_circ.max_x_measurements
-
-    sp_circ.compute_fault_sets()
-    fault_sets = (
-        sp_circ.combine_faults(additional_faults, x_errors)
-        if additional_faults is not None
-        else sp_circ.x_fault_sets
-        if x_errors
-        else sp_circ.z_fault_sets
-    )
+    n_layers = len(fault_sets)
+    layers: list[list[list[npt.NDArray[np.int8]]]] = [[] for _ in range(n_layers)]
+    max_ancillas = stabs.shape[0]
 
     # Find the optimal circuit for every number of errors in the preparation circuit
-    for num_errors in range(1, max_errors + 1):
-        logger.info(f"Finding verification stabilizers for {num_errors} errors")
-        faults = fault_sets[num_errors]
-        assert faults is not None
+    for layer in range(n_layers):
+        logger.info(f"Finding verification stabilizers for {layer} errors")
+        faults = fault_sets[layer]
 
         if len(faults) == 0:
-            logger.info(f"No non-trivial faults for {num_errors} errors")
-            layers[num_errors - 1] = []
+            logger.info(f"No non-trivial faults for {layer} errors")
+            layers[layer] = []
             continue
         # Start with maximal number of ancillas
         # Minimal CNOT solution must be achievable with these
         num_anc = max_ancillas
-        checks = sp_circ.z_checks if x_errors else sp_circ.x_checks
-        min_cnots: int = np.min(np.sum(checks, axis=1))
-        max_cnots: int = np.sum(checks)
+        min_cnots: int = np.min(np.sum(stabs, axis=1))
+        max_cnots: int = np.sum(stabs)
 
         logger.info(
-            f"Finding verification stabilizers for {num_errors} errors with {min_cnots} to {max_cnots} CNOTs using {num_anc} ancillas"
+            f"Finding verification stabilizers for {layer+1} errors with {min_cnots} to {max_cnots} CNOTs using {num_anc} ancillas"
         )
 
         def fun(num_cnots: int) -> list[npt.NDArray[np.int8]] | None:
-            return verification_stabilizers(sp_circ, faults, num_anc, num_cnots, x_errors=x_errors)  # noqa: B023
+            return verification_stabilizers(faults, stabs, num_anc, num_cnots)  # noqa: B023
 
         res = iterative_search_with_timeout(
             fun,
@@ -433,18 +378,18 @@ def all_gate_optimal_verification_stabilizers(
             measurements = None
 
         if measurements is None:
-            logger.info(f"No verification stabilizers found for {num_errors} errors")
+            logger.info(f"No verification stabilizers found for {layer+1} errors")
             return []  # No solution found
 
-        logger.info(f"Found verification stabilizers for {num_errors} errors with {num_cnots} CNOTs")
+        logger.info(f"Found verification stabilizers for {layer+1} errors with {num_cnots} CNOTs")
         # If any measurements are unused we can reduce the number of ancillas at least by that
         measurements = [m for m in measurements if np.any(m)]
         num_anc = len(measurements)
         # Iterate backwards to find the minimal number of cnots
-        logger.info(f"Finding minimal number of CNOTs for {num_errors} errors")
+        logger.info(f"Finding minimal number of CNOTs for {layer+1} errors")
 
         def search_cnots(num_cnots: int) -> list[npt.NDArray[np.int8]] | None:
-            return verification_stabilizers(sp_circ, faults, num_anc, num_cnots, x_errors=x_errors)  # noqa: B023
+            return verification_stabilizers(faults, stabs, num_anc, num_cnots)  # noqa: B023
 
         while num_cnots - 1 > 0:
             logger.info(f"Trying {num_cnots - 1} CNOTs")
@@ -459,15 +404,15 @@ def all_gate_optimal_verification_stabilizers(
                 measurements = cnot_opt
             else:
                 break
-        logger.info(f"Minimal number of CNOTs for {num_errors} errors is: {num_cnots}")
+        logger.info(f"Minimal number of CNOTs for {layer} errors is: {num_cnots}")
 
         # If the number of CNOTs is minimal, we can reduce the number of ancillas
-        logger.info(f"Finding minimal number of ancillas for {num_errors} errors")
+        logger.info(f"Finding minimal number of ancillas for {layer+1} errors")
         while num_anc - 1 > 0:
             logger.info(f"Trying {num_anc - 1} ancillas")
 
             def search_anc(num_anc: int) -> list[npt.NDArray[np.int8]] | None:
-                return verification_stabilizers(sp_circ, faults, num_anc, num_cnots, x_errors=x_errors)  # noqa: B023
+                return verification_stabilizers(faults, stabs, num_anc, num_cnots)  # noqa: B023
 
             anc_opt = run_with_timeout(
                 search_anc,
@@ -479,16 +424,16 @@ def all_gate_optimal_verification_stabilizers(
                 measurements = anc_opt
             else:
                 break
-        logger.info(f"Minimal number of ancillas for {num_errors} errors is: {num_anc}")
+        logger.info(f"Minimal number of ancillas for {layer+1} errors is: {num_anc}")
         if not return_all_solutions:
-            layers[num_errors - 1] = [measurements]
+            layers[layer - 1] = [measurements]
         else:
             all_stabs = all_verification_stabilizers(
-                sp_circ, faults, num_anc, num_cnots, x_errors=x_errors, return_all_solutions=True
+                faults, stabs, num_anc, num_cnots, return_all_solutions=True
             )
             if all_stabs:
-                layers[num_errors - 1] = all_stabs
-                logger.info(f"Found {len(layers[num_errors - 1])} equivalent solutions for {num_errors} errors")
+                layers[layer - 1] = all_stabs
+                logger.info(f"Found {len(layers[layer])} equivalent solutions for {layer} errors")
 
     return layers
 
@@ -496,21 +441,22 @@ def all_gate_optimal_verification_stabilizers(
 def _verification_circuit(
     sp_circ: StatePrepCircuit,
     verification_stabs_fun: Callable[
-        [StatePrepCircuit, bool, npt.NDArray[np.int8] | None], list[list[npt.NDArray[np.int8]]]
+        [list[PureFaultSet]], list[list[npt.NDArray[np.int8]]]
     ],
     full_fault_tolerance: bool = True,
     flag_first_layer: bool = False,
 ) -> QuantumCircuit:
     logger.info("Finding verification stabilizers for the state preparation circuit")
-    layers_1 = verification_stabs_fun(sp_circ, sp_circ.zero_state, None)
+    layers_1 = verification_stabs_fun(sp_circ.x_fault_sets[1:])
     measurements_1 = [measurement for layer in layers_1 for measurement in layer]
 
     if full_fault_tolerance:
         if not flag_first_layer:
             additional_errors = get_hook_errors(measurements_1)
-            layers_2 = verification_stabs_fun(sp_circ, not sp_circ.zero_state, additional_errors)
+            extended_fault_sets = sp_circ.combine_faults(additional_faults=additional_errors, x_errors=False)
+            layers_2 = verification_stabs_fun(extended_fault_sets[1:])
         else:
-            layers_2 = verification_stabs_fun(sp_circ, not sp_circ.zero_state, None)
+            layers_2 = verification_stabs_fun(sp_circ.z_fault_sets[1:])
         measurements_2 = [measurement for layer in layers_2 for measurement in layer]
     else:
         measurements_2 = []
@@ -556,12 +502,10 @@ def gate_optimal_verification_circuit(
     """
 
     def verification_stabs_fun(
-        sp_circ: StatePrepCircuit,
-        zero_state: bool,
-        additional_errors: npt.NDArray[np.int8] | None = None,
+        fault_sets: list[PureFaultSet],
     ) -> list[list[npt.NDArray[np.int8]]]:
         return gate_optimal_verification_stabilizers(
-            sp_circ, zero_state, min_timeout, max_timeout, max_ancillas, additional_errors
+            fault_sets, min_timeout, max_timeout, max_ancillas
         )
 
     return _verification_circuit(
@@ -808,11 +752,10 @@ def _measure_ft_stabs(
 
 
 def verification_stabilizers(
-    sp_circ: StatePrepCircuit,
-    fault_set: npt.NDArray[np.int8],
+    fault_set: PureFaultSet,
+    stabs: npt.NDArray[np.int8],
     num_anc: int,
     num_cnots: int,
-    x_errors: bool = True,
 ) -> list[npt.NDArray[np.int8]] | None:
     """Return a verification stabilizers for num_errors independent errors in the state preparation circuit using z3.
 
@@ -824,7 +767,7 @@ def verification_stabilizers(
         x_errors: If True, the errors are X errors. Otherwise, the errors are Z errors.
     """
     stabs_list = all_verification_stabilizers(
-        sp_circ, fault_set, num_anc, num_cnots, x_errors, return_all_solutions=False
+        fault_set, stabs, num_anc, num_cnots, return_all_solutions=False
     )
     if stabs_list:
         return stabs_list[0]
@@ -832,33 +775,39 @@ def verification_stabilizers(
 
 
 def all_verification_stabilizers(
-    sp_circ: StatePrepCircuit,
-    fault_set: npt.NDArray[np.int8],
+    fault_set: PureFaultSet,
+    stabs: npt.NDArray[np.int8],
     num_anc: int,
     num_cnots: int,
-    x_errors: bool = True,
     return_all_solutions: bool = False,
 ) -> list[list[npt.NDArray[np.int8]]] | None:
-    """Return a list of verification stabilizers for num_errors independent errors in the state preparation circuit using z3.
+    """Return a list of verification stabilizers for independent errors in the state preparation circuit using z3.
 
     Args:
-        sp_circ: The state preparation circuit.
         fault_set: The set of errors to verify.
+        stabs: Stabilizer generators of the stabilizers measured.
         num_anc: The maximum number of ancilla qubits to use.
         num_cnots: The maximum number of CNOT gates to use.
-        x_errors: If True, the errors are X errors. Otherwise, the errors are Z errors.
         return_all_solutions: If True, return all solutions. Otherwise, return the first solution found.
     """
     # Measurements are written as sums of generators
     # The variables indicate which generators are non-zero in the sum
-    gens = sp_circ.z_checks if x_errors else sp_circ.x_checks
-    n_gens = gens.shape[0]
+    if fault_set.faults.shape[1] != stabs.shape[1]:
+        msg = "Fault set and stabilizers must have the same number of qubits."
+        raise ValueError(msg)
+
+    # Check if fault set can be verified, i.e., every fault can be detected by at least one measurement
+    if any(np.any(fault_set.faults@ stabs.T % 2 == 0, axis=1)):
+        logger.warning("Fault set cannot be verified by the given stabilizers. Some faults are not detectable by the given stabilizers.")
+        return None
+    
+    n_gens = stabs.shape[0]
+    n_qubits = stabs.shape[1]
 
     measurement_vars = [[z3.Bool(f"m_{anc}_{i}") for i in range(n_gens)] for anc in range(num_anc)]
+    measurement_stabs = [vars_to_stab(vars_, stabs) for vars_ in measurement_vars]
+
     solver = z3.Solver()
-
-    measurement_stabs = [vars_to_stab(vars_, gens) for vars_ in measurement_vars]
-
     # assert that each error is detected
     solver.add(
         z3.And([
@@ -870,7 +819,7 @@ def all_verification_stabilizers(
     # assert that not too many CNOTs are used
     solver.add(
         z3.PbLe(
-            [(measurement[q], 1) for measurement in measurement_stabs for q in range(sp_circ.num_qubits)], num_cnots
+            [(measurement[q], 1) for measurement in measurement_stabs for q in range(n_qubits)], num_cnots
         )
     )
 
@@ -880,10 +829,10 @@ def all_verification_stabilizers(
         # Extract stabilizer measurements from model
         actual_measurements = []
         for m in measurement_vars:
-            v = np.zeros(sp_circ.num_qubits, dtype=np.int8)
+            v = np.zeros(n_qubits, dtype=np.int8)
             for g in range(n_gens):
                 if model[m[g]]:
-                    v += gens[g]
+                    v += stabs[g]
             actual_measurements.append(v % 2)
         if not return_all_solutions:
             return [actual_measurements]
@@ -892,6 +841,7 @@ def all_verification_stabilizers(
         solver.add(z3.Or([vars_[i] != model[vars_[i]] for vars_ in measurement_vars for i in range(n_gens)]))
     if solutions:
         return solutions
+
     return None
 
 
@@ -977,7 +927,7 @@ def naive_verification_circuit(sp_circ: StatePrepCircuit, flag_first_layer: bool
     return _measure_ft_stabs(sp_circ, z_measurements * reps, x_measurements * reps, flag_first_layer=flag_first_layer)
 
 
-def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> npt.NDArray[np.int8]:
+def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> PureFaultSet:
     """Assuming CNOTs are executed in ascending order of qubit index, this function gives all the hook errors of the given stabilizer measurements."""
     errors = []
     for stab in measurements:
@@ -987,7 +937,7 @@ def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> npt.NDArray[np.
             error[qubit] = 0
             errors.append(error.copy())
 
-    return np.array(errors)
+    return PureFaultSet.from_fault_array(np.array(errors))
 
 
 def final_matrix_constraint(columns: npt.NDArray[z3.BoolRef | bool], rank: int) -> z3.BoolRef:

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -414,7 +414,7 @@ def all_gate_optimal_verification_stabilizers(
                 measurements = cnot_opt
             else:
                 break
-        logger.info(f"Minimal number of CNOTs for {layer+1} errors is: {num_cnots}")
+        logger.info(f"Minimal number of CNOTs for {layer + 1} errors is: {num_cnots}")
 
         # If the number of CNOTs is minimal, we can reduce the number of ancillas
         logger.info(f"Finding minimal number of ancillas for {layer + 1} errors")
@@ -866,7 +866,12 @@ def naive_verification_circuit(sp_circ: StatePrepCircuit, flag_first_layer: bool
 
     z_measurements = code.Hz
     x_measurements = code.Hx
-    return _measure_ft_stabs(sp_circ, z_measurements * sp_circ.max_z_errors, x_measurements * sp_circ.max_x_errors, flag_first_layer=flag_first_layer)
+    return _measure_ft_stabs(
+        sp_circ,
+        z_measurements * sp_circ.max_z_errors,
+        x_measurements * sp_circ.max_x_errors,
+        flag_first_layer=flag_first_layer,
+    )
 
 
 def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> PureFaultSet:

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -20,6 +20,7 @@ from qiskit.circuit import AncillaRegister, ClassicalRegister, QuantumCircuit, Q
 from qiskit.converters import circuit_to_dag
 
 from ..codes import InvalidCSSCodeError
+from .faults import coset_leader
 from .synthesis_utils import (
     build_css_circuit_from_cnot_list,
     heuristic_gaussian_elimination,
@@ -28,9 +29,7 @@ from .synthesis_utils import (
     odd_overlap,
     optimal_elimination,
     run_with_timeout,
-    symbolic_scalar_mult,
-    symbolic_vector_add,
-    symbolic_vector_eq,
+    vars_to_stab,
 )
 
 logger = logging.getLogger(__name__)
@@ -808,16 +807,6 @@ def _measure_ft_stabs(
     return measured_circ
 
 
-def vars_to_stab(
-    measurement: list[z3.BoolRef | bool], generators: npt.NDArray[np.int8]
-) -> npt.NDArray[z3.BoolRef | bool]:
-    """Compute the stabilizer measured giving the generators and the measurement variables."""
-    measurement_stab = symbolic_scalar_mult(generators[0], measurement[0])
-    for i, scalar in enumerate(measurement[1:]):
-        measurement_stab = symbolic_vector_add(measurement_stab, symbolic_scalar_mult(generators[i + 1], scalar))
-    return measurement_stab
-
-
 def verification_stabilizers(
     sp_circ: StatePrepCircuit,
     fault_set: npt.NDArray[np.int8],
@@ -904,24 +893,6 @@ def all_verification_stabilizers(
     if solutions:
         return solutions
     return None
-
-
-def coset_leader(error: npt.NDArray[np.int8], generators: npt.NDArray[np.int8]) -> npt.NDArray[np.int8]:
-    """Compute the coset leader of an error given a set of generators."""
-    if len(generators) == 0:
-        return error
-    s = z3.Optimize()
-    leader = [z3.Bool(f"e_{i}") for i in range(len(error))]
-    coeff = [z3.Bool(f"c_{i}") for i in range(len(generators))]
-
-    g = vars_to_stab(coeff, generators)
-
-    s.add(symbolic_vector_eq(np.array(leader), symbolic_vector_add(error.astype(bool), g)))
-    s.minimize(z3.Sum(leader))
-
-    s.check()  # always SAT
-    m = s.model()
-    return np.array([bool(m[leader[i]]) for i in range(len(error))]).astype(int)
 
 
 def _propagate_error(nodes: list[DAGNode], n_qubits: int, x_errors: bool = True) -> PauliList:

--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -866,12 +866,7 @@ def naive_verification_circuit(sp_circ: StatePrepCircuit, flag_first_layer: bool
 
     z_measurements = code.Hz
     x_measurements = code.Hx
-    return _measure_ft_stabs(
-        sp_circ,
-        z_measurements * sp_circ.max_z_errors,
-        x_measurements * sp_circ.max_x_errors,
-        flag_first_layer=flag_first_layer,
-    )
+    return _measure_ft_stabs(sp_circ, z_measurements * sp_circ.max_z_errors, x_measurements * sp_circ.max_x_errors, flag_first_layer=flag_first_layer)
 
 
 def get_hook_errors(measurements: list[npt.NDArray[np.int8]]) -> PureFaultSet:

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING
 
@@ -18,7 +19,7 @@ import numpy.typing as npt
 import z3
 from ldpc import mod2
 
-from .faults import coset_leader
+from .faults import PureFaultSet, coset_leader
 from .state_prep import (
     StatePrepCircuit,
     all_gate_optimal_verification_stabilizers,
@@ -34,11 +35,11 @@ from .synthesis_utils import (
 )
 
 logger = logging.getLogger(__name__)
-from .faults import PureFaultSet
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from ..codes import CSSCode
 
 Recovery = tuple[list[npt.NDArray[np.int8]], dict[int, npt.NDArray[np.int8]]]
 Recoveries = dict[int, Recovery]
@@ -51,22 +52,22 @@ class DeterministicVerification:
 
     def __init__(
         self,
-        verification_stabs: Verification,
+        nd_verification_stabs: Verification,
         det_correction: DeterministicCorrection,
         hook_corrections: list[DeterministicCorrection] | None = None,
     ) -> None:
         """Initialize a deterministic verification object.
 
         Args:
-            and_verification_stabs: The non-deterministic verification stabilizers to be measured.
+            nd_verification_stabs: The non-deterministic verification stabilizers to be measured.
             det_correction: The deterministic correction for the non-deterministic verification stabilizers.
             hook_corrections: the hook corrections for the non-deterministic verification stabilizers.
         """
-        self.stabs = verification_stabs
+        self.stabs = nd_verification_stabs
         self.det_correction = det_correction
-        self.hook_corrections: list[DeterministicCorrection] = [{}] * len(verification_stabs)
+        self.hook_corrections: list[DeterministicCorrection] = [{}] * len(nd_verification_stabs)
         if hook_corrections:
-            assert len(hook_corrections) == len(verification_stabs)
+            assert len(hook_corrections) == len(nd_verification_stabs)
             self.hook_corrections = hook_corrections
 
     def copy(self) -> DeterministicVerification:
@@ -187,7 +188,9 @@ class DeterministicVerification:
 class DeterministicVerificationHelper:
     """Class to compute the deterministic verification stabilizers and corrections for a given state preparation circuit."""
 
-    def __init__(self, state_prep: StatePrepCircuit, use_optimal_verification: bool = True, verify_x_first:bool=True) -> None:
+    def __init__(
+        self, state_prep: StatePrepCircuit, use_optimal_verification: bool = True, verify_x_first: bool = True
+    ) -> None:
         """Initialize the deterministic verification helper with a given state preparation circuit.
 
         Args:
@@ -205,7 +208,6 @@ class DeterministicVerificationHelper:
         self._layers: list[list[DeterministicVerification]] = [[], []]
         # Variable to store the deterministic verification stabilizers and corrections for the hook propagation solution
         self._hook_propagation_solutions: list[tuple[DeterministicVerification, DeterministicVerification]] = []
-
 
         self.state_prep.compute_fault_sets()
         if self.verify_x_first:
@@ -231,7 +233,7 @@ class DeterministicVerificationHelper:
             compute_all_solutions: If True, all equivalent verification stabilizers are computed and stored.
         """
         for layer in range(2):
-            logger.info(f"Computing non-deterministic verification stabilizers for layer {layer+1}.")
+            logger.info(f"Computing non-deterministic verification stabilizers for layer {layer + 1}.")
             stabs_all = all_gate_optimal_verification_stabilizers(
                 [self.fault_sets[layer]],
                 self.checks[layer],
@@ -254,7 +256,7 @@ class DeterministicVerificationHelper:
             self._layers[layer_idx][verify_idx].det_correction = deterministic_correction(
                 self.fault_sets[layer_idx],
                 self.checks[layer_idx],
-                self.checks[1-layer_idx],
+                self.checks[1 - layer_idx],
                 verify.stabs,
                 min_timeout=min_timeout,
                 max_timeout=max_timeout,
@@ -276,9 +278,7 @@ class DeterministicVerificationHelper:
         n = stabs.shape[1]
         for error in hook_errors:
             single_qubit_deviation = (error + np.eye(n, dtype=np.int8)) % 2
-            stabs_plus_single_qubit = np.concatenate(
-                [stabs] + [single_qubit_deviation], axis=0
-            )
+            stabs_plus_single_qubit = np.concatenate([stabs, single_qubit_deviation], axis=0)
             if not any(mod2.rank(stabs_plus_single_qubit[:, :n]) == rank for _ in range(n)):
                 return False
         return True
@@ -301,16 +301,18 @@ class DeterministicVerificationHelper:
 
                 for stab_idx, stab in enumerate(verify.stabs):
                     hook_errors = get_hook_errors([stab])
-                    if self._trivial_hook_errors(hook_errors, self.checks[1-layer_idx]):
+                    if self._trivial_hook_errors(hook_errors, self.checks[1 - layer_idx]):
                         continue
 
                     # hook errors are non-trivial
                     # add case of error on hook ancilla
-                    hook_errors = PureFaultSet.from_fault_array(np.vstack((hook_errors, np.zeros(self.num_qubits, dtype=np.int8))))
+                    hook_errors = PureFaultSet.from_fault_array(
+                        np.vstack((hook_errors, np.zeros(self.num_qubits, dtype=np.int8)))
+                    )
                     self._layers[layer_idx][verify_idx].hook_corrections[stab_idx] = {
                         1: deterministic_correction_single_outcome(
                             hook_errors,
-                            self.checks[1-layer_idx],
+                            self.checks[1 - layer_idx],
                             self.checks[layer_idx],
                             min_timeout=min_timeout,
                             max_timeout=max_timeout,
@@ -429,8 +431,7 @@ class DeterministicVerificationHelper:
         for verify in self._layers[0]:
             logger.info(f"Computing hook propagation solutions for verification {verify} / {len(self._layers[0])}.")
             stabs_flagged_all = [
-                not self._trivial_hook_errors(get_hook_errors([stab]), self.checks[0])
-                for stab in verify.stabs
+                not self._trivial_hook_errors(get_hook_errors([stab]), self.checks[0]) for stab in verify.stabs
             ]
 
             stabs_flagged_all_indices = [idx for idx, flag in enumerate(stabs_flagged_all) if flag]
@@ -465,9 +466,7 @@ class DeterministicVerificationHelper:
                         return_all_solutions=compute_all_solutions,
                     )[0]
                 else:
-                    stabs_2_list = heuristic_verification_stabilizers(
-                        fault_set, self.checks[1]
-                    )[0]
+                    stabs_2_list = heuristic_verification_stabilizers(fault_set, self.checks[1])[0]
                     stabs_2_list = [stabs_2_list]
                 verify_2_list = [DeterministicVerification(stabs_2, {}) for stabs_2 in stabs_2_list]
                 # check if better than normal verification
@@ -544,7 +543,6 @@ class DeterministicVerificationHelper:
         # Trivial case: no verification stabilizers
         return DeterministicVerification([], {}), DeterministicVerification([], {})
 
-
     def get_global_solution(
         self,
         min_timeout: int = 1,
@@ -583,7 +581,7 @@ class DeterministicVerificationHelper:
         # Compute hook propagation solutions
         self._compute_hook_propagation_solutions(
             min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, compute_all_solutions=False
-            )
+        )
 
         # if hook propagation is worse, compute the hook corrections and deterministic corrections
         if len(self._hook_propagation_solutions) == 0:
@@ -644,13 +642,13 @@ def deterministic_correction(
     stabilizers for each non-deterministic verification outcome separately.
 
     Args:
-        sp_circ: The state preparation circuit to compute the deterministic verification for.
-        and_d3_verification_stabilizers: The non-deterministic verification stabilizers to be measured.
+        fault_set: The set of errors to consider for the deterministic verification.
+        verification_gens: The stabilizer generators used for verification.
+        correction_gens: The stabilizer generators the faults can be multiplied by.
+        nd_d3_verification_stabilizers: The non-deterministic verification stabilizers to be measured.
         min_timeout: The minimum time in seconds to run the verification stabilizers.
         max_timeout: The maximum time in seconds to run the verification stabilizers.
         max_ancillas: The maximum number of ancillas to use in the verification stabilizers.
-        zero_state: If True, the X errors are considered, otherwise the Z errors are considered.
-        additional_faults: Additional faults to consider in the fault set (e.g. hook errors).
     """
     num_nd_stabs = len(nd_d3_verification_stabilizers)
     num_qubits = fault_set.num_qubits
@@ -667,23 +665,18 @@ def deterministic_correction(
         )
 
         # only consider errors that triggered the verification pattern
-        def triggers_pattern(fault: npt.NDArray[np.int8]) -> bool:
-            return np.array_equal(
-                verify_outcome, [np.sum(m * fault) % 2 for m in nd_d3_verification_stabilizers]
-                )
+        def triggers_pattern(fault: npt.NDArray[np.int8], verify_outcome: npt.NDArray[np.int8]) -> bool:
+            return np.array_equal(verify_outcome, nd_d3_verification_stabilizers @ fault % 2)
 
-        errors_filtered = fault_set.filter_faults(triggers_pattern, inplace=False)
-        logger.info(
-            f"First Filtered errors for verification outcome {verify_outcome_int}: {len(errors_filtered)} errors."
+        errors_filtered = fault_set.filter_faults(
+            partial(triggers_pattern, verify_outcome=verify_outcome), inplace=False
         )
         # append single-qubit errors that could have triggered the verification pattern
         identity_matrix = np.eye(num_qubits, dtype=np.int8)
         for qubit in range(num_qubits):
             single_qubit_error = identity_matrix[qubit]
             # compute error pattern of single-qubit error on qubit i
-            error_pattern = [
-                np.sum(m * single_qubit_error) % 2 for m in nd_d3_verification_stabilizers
-            ]
+            error_pattern = [np.sum(m * single_qubit_error) % 2 for m in nd_d3_verification_stabilizers]
 
             for i in range(num_nd_stabs):
                 if np.array_equal(verify_outcome, error_pattern):
@@ -693,9 +686,6 @@ def deterministic_correction(
                     error_pattern[i] = 0
             errors_filtered.remove_duplicates()
 
-        logger.info(
-            f"Filtered errors for verification outcome {verify_outcome_int}: {len(errors_filtered)} errors."
-        )
         # add the no-error case for the error being on one of the verification ancillas
         if np.sum(verify_outcome) == 1:
             errors_filtered.add_fault(np.zeros(num_qubits, dtype=np.int8))
@@ -732,7 +722,8 @@ def deterministic_correction_single_outcome(
 
     Args:
         fault_set: The set of errors to consider for the deterministic verification.
-        stabs: The stabilizer generators used for verification.
+        verification_gens: The stabilizer generators used for verification.
+        correction_gens: The stabilizer generators the faults can be multiplied by.
         min_timeout: The minimum time in seconds to run the verification stabilizers.
         max_timeout: The maximum time in seconds to run the verification stabilizers.
         max_ancillas: The maximum number of ancillas to use in the verification stabilizers.
@@ -740,7 +731,7 @@ def deterministic_correction_single_outcome(
     num_anc = 1
     num_qubits = fault_set.num_qubits
     if max_ancillas is None:
-        max_ancillas = verification_gens.shape[0]+ correction_gens.shape[0]
+        max_ancillas = verification_gens.shape[0] + correction_gens.shape[0]
 
     def _func(num_anc: int) -> Recovery | None:
         return correction_stabilizers(fault_set, verification_gens, correction_gens, num_anc, num_anc * num_qubits)
@@ -790,7 +781,6 @@ def correction_stabilizers(
     correction_gens: npt.NDArray[np.int8],
     num_anc: int,
     num_cnot: int,
-    x_errors: bool = True,
 ) -> Recovery | None:
     """Return deterministic verification stabilizers with corresponding corrections using z3."""
     n_gens = measurement_gens.shape[0]

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -18,19 +18,19 @@ import numpy.typing as npt
 import z3
 from ldpc import mod2
 
+from .faults import coset_leader
 from .state_prep import (
     StatePrepCircuit,
     all_gate_optimal_verification_stabilizers,
-    coset_leader,
     get_hook_errors,
     heuristic_verification_stabilizers,
-    vars_to_stab,
 )
 from .synthesis_utils import (
     iterative_search_with_timeout,
     odd_overlap,
     run_with_timeout,
     symbolic_vector_eq,
+    vars_to_stab,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -658,12 +658,6 @@ def deterministic_correction(
         max_ancillas = verification_gens.shape[0] + correction_gens.shape[0]
 
     logger.info("Fault set has %s faults.", len(fault_set))
-    # get the fault set
-    # TODO: Calling context has to handle fault set extension
-    # if additional_faults is not None:
-    #     fault_set = sp_circ.combine_faults(additional_faults=additional_faults, x_errors=zero_state)
-    # else:
-    #     fault_set = sp_circ.compute_fault_set(1, x_errors=zero_state)
 
     det_verify = {}
     for verify_outcome_int in range(1, 2**num_nd_stabs):
@@ -696,6 +690,9 @@ def deterministic_correction(
                     error_pattern[i] = 0
             errors_filtered.remove_duplicates()
 
+        logger.info(
+            f"Filtered errors for verification outcome {verify_outcome_int}: {len(errors_filtered)} errors."
+        )
         # add the no-error case for the error being on one of the verification ancillas
         if np.sum(verify_outcome) == 1:
             errors_filtered.add_fault(np.zeros(num_qubits, dtype=np.int8))

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -51,7 +51,7 @@ class DeterministicVerification:
 
     def __init__(
         self,
-        and_verification_stabs: Verification,
+        verification_stabs: Verification,
         det_correction: DeterministicCorrection,
         hook_corrections: list[DeterministicCorrection] | None = None,
     ) -> None:
@@ -62,11 +62,11 @@ class DeterministicVerification:
             det_correction: The deterministic correction for the non-deterministic verification stabilizers.
             hook_corrections: the hook corrections for the non-deterministic verification stabilizers.
         """
-        self.stabs = and_verification_stabs
+        self.stabs = verification_stabs
         self.det_correction = det_correction
-        self.hook_corrections: list[DeterministicCorrection] = [{}] * len(and_verification_stabs)
+        self.hook_corrections: list[DeterministicCorrection] = [{}] * len(verification_stabs)
         if hook_corrections:
-            assert len(hook_corrections) == len(and_verification_stabs)
+            assert len(hook_corrections) == len(verification_stabs)
             self.hook_corrections = hook_corrections
 
     def copy(self) -> DeterministicVerification:
@@ -206,6 +206,7 @@ class DeterministicVerificationHelper:
         # Variable to store the deterministic verification stabilizers and corrections for the hook propagation solution
         self._hook_propagation_solutions: list[tuple[DeterministicVerification, DeterministicVerification]] = []
 
+
         self.state_prep.compute_fault_sets()
         if self.verify_x_first:
             self.fault_sets = [self.state_prep.x_fault_sets[0], self.state_prep.z_fault_sets[0]]
@@ -239,9 +240,7 @@ class DeterministicVerificationHelper:
                 max_ancillas=max_ancillas,
                 return_all_solutions=compute_all_solutions,
             )[0]
-            for stabs in stabs_all:
-                verify = DeterministicVerification(stabs, {})
-                self._layers[0].append(verify)
+            self._layers[layer] = [DeterministicVerification(stabs, {}) for stabs in stabs_all]
 
     def _compute_det_corrections(
         self, min_timeout: int = 1, max_timeout: int = 3600, max_ancillas: int | None = None, layer_idx: int = 0
@@ -263,80 +262,88 @@ class DeterministicVerificationHelper:
             )
 
     @staticmethod
-    def _trivial_hook_errors(hook_errors: list[npt.NDArray[np.int8]], code: CSSCode, x_error: bool) -> bool:
+    def _trivial_hook_errors(hook_errors: PureFaultSet, stabs: npt.NDArray[np.int8]) -> bool:
         """Checks if the hook errors are trivial (stabilizers) by checking if the rank of the code stabilizers is the same.
 
         Args:
             hook_errors: The hook errors to check.
-            code: The CSS code to check the rank of the stabilizers.
-            x_error: If True, the Z stabilizers are checked, otherwise the X stabilizers are checked.
+            stabs: The CSS code to check the rank of the stabilizers.
 
         Returns:
             bool: True if all hook errors are trivial, False otherwise.
         """
-        errors_trivial = []
-        code_stabs = np.vstack((code.Hz, code.Lz)) if x_error else np.vstack((code.Hx, code.Lx))
-        rank = mod2.rank(code_stabs)
+        rank = mod2.rank(stabs)
+        n = stabs.shape[1]
         for error in hook_errors:
-            single_qubit_deviation = [(error + np.eye(code.n, dtype=np.int8)[i]) % 2 for i in range(code.n)]
-            stabs_plus_single_qubit = [np.vstack((code_stabs, single_qubit_deviation[i])) for i in range(code.n)]
-            trivial = any(mod2.rank(m) == rank for m in stabs_plus_single_qubit)
-            errors_trivial.append(trivial)
-        return bool(all(errors_trivial))
+            single_qubit_deviation = (error + np.eye(n, dtype=np.int8)) % 2
+            stabs_plus_single_qubit = np.concatenate(
+                [stabs] + [single_qubit_deviation], axis=0
+            )
+            if not any(mod2.rank(stabs_plus_single_qubit[:, :n]) == rank for _ in range(n)):
+                return False
+        return True
 
     def _compute_hook_corrections(
         self, min_timeout: int = 1, max_timeout: int = 3600, max_ancillas: int | None = None
     ) -> None:
         """Computes the additional stabilizers to measure with corresponding corrections for the hook errors of each stabilizer measurement in layer 2."""
-        for layer_idx, x_error in enumerate([self.verify_x_first, not self.verify_x_first]):
+        for layer_idx in range(2):
             logger.info(f"Computing deterministic verification for hook errors of layer {layer_idx + 1} / 2.")
             for verify_idx, verify in enumerate(self._layers[layer_idx]):
                 logger.info(
                     f"Computing deterministic hook correction for non-det verification {verify_idx + 1} / {len(self._layers[layer_idx])}."
                 )
+
+                # No stabilizers are measured, so no hook errors can occur
                 if not verify.stabs:
                     self._layers[layer_idx][verify_idx].hook_corrections = [{}] * len(verify.stabs)
                     continue
+                
                 for stab_idx, stab in enumerate(verify.stabs):
-                    hook_errors = list(get_hook_errors([stab]))
-                    if self._trivial_hook_errors(hook_errors, self.code, not x_error):
+                    hook_errors = get_hook_errors([stab])
+                    if self._trivial_hook_errors(hook_errors, self.checks[1-layer_idx]):
                         continue
 
                     # hook errors are non-trivial
                     # add case of error on hook ancilla
-                    hook_errors = np.vstack((hook_errors, np.zeros(self.num_qubits, dtype=np.int8)))
+                    hook_errors = PureFaultSet.from_fault_array(np.vstack((hook_errors, np.zeros(self.num_qubits, dtype=np.int8))))
                     self._layers[layer_idx][verify_idx].hook_corrections[stab_idx] = {
                         1: deterministic_correction_single_outcome(
-                            self.state_prep,
                             hook_errors,
+                            self.checks[1-layer_idx],
+                            self.checks[layer_idx],
                             min_timeout=min_timeout,
                             max_timeout=max_timeout,
                             max_ancillas=max_ancillas,
-# TODO                            zero_state=not x_error,
                         )
                     }
 
-    def _filter_and_stabs(self) -> None:
+    def _filter_nd_stabs(self) -> None:
         """Only keep the best non-deterministic verification stabilizers with minimal number of ancillas and CNOTs."""
         self._best_num_anc = 0
         self._best_num_cnots = 0
-        for layer_idx in range(2):
-            # get best numbers
+
+        for layer_idx, layer in enumerate(self._layers[:2]):
+            # Compute best numbers and indices
             best_num_anc = int(1e6)
             best_num_cnots = int(1e6)
             best_case_indices = []
-            for idx_verify, verify in enumerate(self._layers[layer_idx]):
+
+            for idx_verify, verify in enumerate(layer):
                 num_anc = verify.num_ancillas_verification() + verify.num_ancillas_hooks()
                 num_cnot = verify.num_cnots_verification() + verify.num_cnots_hooks()
-                if best_num_anc > num_anc or (best_num_anc == num_anc and best_num_cnots > num_cnot):
+
+                if (num_anc < best_num_anc) or (num_anc == best_num_anc and num_cnot < best_num_cnots):
                     best_num_anc = num_anc
                     best_num_cnots = num_cnot
                     best_case_indices = [idx_verify]
-                elif best_num_anc == num_anc and best_num_cnots == num_cnot:
+                elif num_anc == best_num_anc and num_cnot == best_num_cnots:
                     best_case_indices.append(idx_verify)
-            # filter out all but the best case
-            self._layers[layer_idx] = [self._layers[layer_idx][idx] for idx in best_case_indices]
-            # save the best numbers
+
+            # Filter out all but the best cases
+            self._layers[layer_idx] = [layer[idx] for idx in best_case_indices]
+
+            # Update the best numbers
             self._best_num_anc += best_num_anc
             self._best_num_cnots += best_num_cnots
 
@@ -351,27 +358,28 @@ class DeterministicVerificationHelper:
     ) -> None:
         for verify_2_idx, verify_2 in enumerate(verify_2_list):
             verify_2_list[verify_2_idx].det_correction = deterministic_correction(
-                self.state_prep,
+                self.fault_sets[1],
+                self.checks[1],
+                self.checks[0],
                 verify_2.stabs,
                 min_timeout=min_timeout,
                 max_timeout=max_timeout,
                 max_ancillas=max_ancillas,
-                zero_state=not self.state_prep.zero_state,
             )
             for stab_idx, stab in enumerate(verify_2.stabs):
-                hook_errors_2 = list(get_hook_errors([stab]))
-                if self._trivial_hook_errors(hook_errors_2, self.code, self.state_prep.zero_state):
+                hook_errors_2 = get_hook_errors([stab])
+                if self._trivial_hook_errors(hook_errors_2, self.checks[0]):
                     verify_2_list[verify_2_idx].hook_corrections[stab_idx] = {}
                 else:
-                    hook_errors_2 = np.vstack((hook_errors_2, np.zeros(self.num_qubits, dtype=np.int8)))
+                    hook_errors_2.add_faults(np.zeros(self.num_qubits, dtype=np.int8))
                     verify_2_list[verify_2_idx].hook_corrections[stab_idx] = {
                         1: deterministic_correction_single_outcome(
-                            self.state_prep,
                             hook_errors_2,
+                            self.checks[0],
+                            self.checks[1],
                             min_timeout=min_timeout,
                             max_timeout=max_timeout,
                             max_ancillas=max_ancillas,
-                            zero_state=self.state_prep.zero_state,
                         )
                     }
 
@@ -394,12 +402,12 @@ class DeterministicVerificationHelper:
             if flag:
                 verify_new.hook_corrections[idx] = {
                     1: deterministic_correction_single_outcome(
-                        self.state_prep,
                         get_hook_errors([verify.stabs[idx]]),
+                        self.checks[1],
+                        self.checks[0],
                         min_timeout=min_timeout,
                         max_timeout=max_timeout,
                         max_ancillas=max_ancillas,
-                        zero_state=not self.state_prep.zero_state,
                     )
                 }
             else:
@@ -416,20 +424,15 @@ class DeterministicVerificationHelper:
     ) -> None:
         """Computes the second layer assuming the hook errors are not flagged but propagated."""
         if not self._layers[1]:
-            # no second layer
             return
 
         for verify in self._layers[0]:
             logger.info(f"Computing hook propagation solutions for verification {verify} / {len(self._layers[0])}.")
-            # create possible combinations of which hook errors are flagged
-            # need_hook_corrections = [
-            #     not self._trivial_hook_errors(_hook_errors([stab]), self.code, not x_errors) for stab in stabs
-            # ]
             stabs_flagged_all = [
-                not self._trivial_hook_errors(get_hook_errors([stab]), self.code, not self.layer_x_errors[0])
+                not self._trivial_hook_errors(get_hook_errors([stab]), self.checks[0])
                 for stab in verify.stabs
             ]
-            # stabs_flagged_all = [True if hook else False for hook in verify.hook_corrections]
+
             stabs_flagged_all_indices = [idx for idx, flag in enumerate(stabs_flagged_all) if flag]
             stabs_flagged_indices_combs = list(product([False, True], repeat=len(stabs_flagged_all_indices)))[:-1]
             stabs_flagged_combs = []
@@ -442,27 +445,28 @@ class DeterministicVerificationHelper:
             # iterate over combinations:
             for stabs_flagged in stabs_flagged_combs:
                 # get hook errors
-                hook_errors = np.empty((0, self.num_qubits), dtype=np.int8)
+                hook_errors = PureFaultSet(self.num_qubits)
                 for idx, flag in enumerate(stabs_flagged):
                     if not flag:
-                        hook_errors = np.vstack((hook_errors, get_hook_errors([verify.stabs[idx]])))
-                if self._trivial_hook_errors(hook_errors, self.code, not self.state_prep.zero_state):
+                        hook_errors.combine(get_hook_errors([verify.stabs[idx]]), inplace=True)
+
+                if self._trivial_hook_errors(hook_errors, self.checks[0]):
                     continue
                 # hook errors require different verification in second layer
                 # compute new verification
+                fault_set = self.state_prep.combine_faults(hook_errors, x_errors=not self.verify_x_first, reduce=True)
                 if self.use_optimal_verification:
                     stabs_2_list = all_gate_optimal_verification_stabilizers(
-                        self.state_prep,
-                        x_errors=not self.state_prep.zero_state,
+                        fault_set,
+                        self.checks[1],
                         min_timeout=min_timeout,
                         max_timeout=max_timeout,
                         max_ancillas=max_ancillas,
-                        additional_faults=hook_errors,
                         return_all_solutions=compute_all_solutions,
                     )[0]
                 else:
                     stabs_2_list = heuristic_verification_stabilizers(
-                        self.state_prep, x_errors=not self.state_prep.zero_state, additional_faults=hook_errors
+                        fault_set, self.checks[1]
                     )[0]
                     stabs_2_list = [stabs_2_list]
                 verify_2_list = [DeterministicVerification(stabs_2, {}) for stabs_2 in stabs_2_list]
@@ -481,6 +485,9 @@ class DeterministicVerificationHelper:
                 )
                 if anc_saved > 0 or (anc_saved == 0 and cnots_saved > 0):
                     # hook propagation is better than hook correction
+                    logger.info(
+                        f"Hook propagation is better than hook correction for verification {verify} / {len(self._layers[0])}."
+                    )
                     # compute deterministic verification
                     self._recompute_hook_propagation_corrections(
                         verify_2_list, verify, stabs_flagged, min_timeout, max_timeout, max_ancillas
@@ -499,24 +506,44 @@ class DeterministicVerificationHelper:
         self.use_optimal_verification = use_optimal_verification
 
         self._compute_non_det_stabs(min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas)
-        self._compute_det_corrections(
-            min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=0
-        )
-        self._compute_hook_propagation_solutions(
-            min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, compute_all_solutions=False
-        )
 
-        # if hook propagation is worse, compute the hook corrections and deterministic corrections
-        if len(self._hook_propagation_solutions) == 0:
-            self._compute_hook_corrections(min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas)
+        # Handle the first layer
+        if self._layers[0]:
+            self._compute_det_corrections(
+                min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=0
+            )
+
+            # If the second layer is empty, return the first layer and a trivial deterministic verification
+            if not self._layers[1]:
+                return self._layers[0][0], DeterministicVerification([], {})
+
+            # Compute hook propagation solutions
+            self._compute_hook_propagation_solutions(
+                min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, compute_all_solutions=False
+            )
+            # If no hook propagation solutions exist, compute hook corrections and deterministic corrections
+            if not self._hook_propagation_solutions:
+                self._compute_hook_corrections(
+                    min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas
+                )
+                self._compute_det_corrections(
+                    min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=1
+                )
+                return self._layers[0][0], self._layers[1][0]
+
+            # Return the best hook propagation solution
+            return self._hook_propagation_solutions[0]
+
+        # Handle the second layer if the first layer is empty
+        if self._layers[1]:
             self._compute_det_corrections(
                 min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=1
             )
-            if len(self._layers[1]) == 0:
-                return self._layers[0][0], DeterministicVerification([], {})
-            return self._layers[0][0], self._layers[1][0]
-        # else return the hook propagation solution
-        return self._hook_propagation_solutions[0]
+            return DeterministicVerification([], {}), self._layers[1][0]
+
+        # Trivial case: no verification stabilizers
+        return DeterministicVerification([], {}), DeterministicVerification([], {})
+        
 
     def get_global_solution(
         self,
@@ -531,13 +558,32 @@ class DeterministicVerificationHelper:
         self._compute_non_det_stabs(
             min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, compute_all_solutions=True
         )
-        self._filter_and_stabs()
+
+        if not self._layers[0] and not self._layers[1]:
+            # Trivial case: no verification stabilizers
+            return DeterministicVerification([], {}), DeterministicVerification([], {})
+        
+        if not self._layers[0] and self._layers[1]:
+            self._compute_det_corrections(
+                min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=1
+            )
+            return DeterministicVerification([], {}), self._layers[1][0]
+        
+        if self._layers[0] and not self._layers[1]:
+            self._compute_det_corrections(
+                min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=0
+            )
+            return self._layers[1][0], DeterministicVerification([], {})
+
+        # Both layers are non-trivial -> find best combination
         self._compute_det_corrections(
             min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=0
         )
+        self._filter_nd_stabs()
+        # Compute hook propagation solutions
         self._compute_hook_propagation_solutions(
             min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, compute_all_solutions=False
-        )
+            )
 
         # if hook propagation is worse, compute the hook corrections and deterministic corrections
         if len(self._hook_propagation_solutions) == 0:
@@ -560,6 +606,10 @@ class DeterministicVerificationHelper:
                         best_stab_indices[layer_idx] = idx_verify
             if len(self._layers[1]) == 0:
                 return self._layers[0][best_stab_indices[0]], DeterministicVerification([], {})
+            
+            if len(self._layers[0]) == 0:
+                return DeterministicVerification([], {}), self._layers[1][best_stab_indices[1]]
+            
             return self._layers[0][best_stab_indices[0]], self._layers[1][best_stab_indices[1]]
 
         # else return the hook propagation solution
@@ -583,7 +633,7 @@ def deterministic_correction(
     fault_set: PureFaultSet,
     verification_gens: npt.NDArray[np.int8],
     correction_gens: npt.NDArray[np.int8],
-    and_d3_verification_stabilizers: list[npt.NDArray[np.int8]],
+    nd_d3_verification_stabilizers: list[npt.NDArray[np.int8]],
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
@@ -602,7 +652,7 @@ def deterministic_correction(
         zero_state: If True, the X errors are considered, otherwise the Z errors are considered.
         additional_faults: Additional faults to consider in the fault set (e.g. hook errors).
     """
-    num_and_stabs = len(and_d3_verification_stabilizers)
+    num_nd_stabs = len(nd_d3_verification_stabilizers)
     num_qubits = fault_set.num_qubits
     if max_ancillas is None:
         max_ancillas = verification_gens.shape[0] + correction_gens.shape[0]
@@ -615,52 +665,52 @@ def deterministic_correction(
     #     fault_set = sp_circ.compute_fault_set(1, x_errors=zero_state)
 
     det_verify = {}
-    for verify_outcome_int in range(1, 2**num_and_stabs):
-        verify_outcome = _int_to_int8_array(verify_outcome_int, num_and_stabs)
+    for verify_outcome_int in range(1, 2**num_nd_stabs):
+        verify_outcome = _int_to_int8_array(verify_outcome_int, num_nd_stabs)
         logger.info(
-            f"Computing deterministic verification for non-det outcome {verify_outcome}: {verify_outcome_int}/{2**num_and_stabs - 1}"
+            f"Computing deterministic verification for non-det outcome {verify_outcome}: {verify_outcome_int}/{2**num_nd_stabs - 1}"
         )
 
         # only consider errors that triggered the verification pattern
-        errors_filtered = np.array([
-            error
-            for error in fault_set
-            if np.array_equal(verify_outcome, [np.sum(m * error) % 2 for m in and_d3_verification_stabilizers])
-        ])
-
+        def triggers_pattern(fault: npt.NDArray[np.int8]) -> bool:
+            return np.array_equal(
+                verify_outcome, [np.sum(m * fault) % 2 for m in nd_d3_verification_stabilizers]
+                )
+        errors_filtered = fault_set.filter_faults(triggers_pattern, inplace=False)
         # append single-qubit errors that could have triggered the verification pattern
+        identity_matrix = np.eye(num_qubits, dtype=np.int8)
         for qubit in range(num_qubits):
+            single_qubit_error = identity_matrix[qubit]
             # compute error pattern of single-qubit error on qubit i
             error_pattern = [
-                np.sum(m * np.eye(num_qubits, dtype=np.int8)[qubit]) % 2 for m in and_d3_verification_stabilizers
+                np.sum(m * single_qubit_error) % 2 for m in nd_d3_verification_stabilizers
             ]
-            for i in range(num_and_stabs):
+
+            for i in range(num_nd_stabs):
                 if np.array_equal(verify_outcome, error_pattern):
-                    # if not already in the fault set
-                    if len(errors_filtered) == 0:
-                        errors_filtered = np.array([np.eye(num_qubits, dtype=np.int8)[qubit]])
-                    elif not np.any(np.all(errors_filtered == np.eye(num_qubits, dtype=np.int8)[qubit], axis=1)):
-                        errors_filtered = np.vstack((errors_filtered, np.eye(num_qubits, dtype=np.int8)[qubit]))
+                    # Add the fault to the set if not already present
+                    errors_filtered.add_fault(single_qubit_error)
                 else:
                     error_pattern[i] = 0
+            errors_filtered.remove_duplicates()
 
         # add the no-error case for the error being on one of the verification ancillas
         if np.sum(verify_outcome) == 1:
-            errors_filtered = np.vstack((errors_filtered, np.zeros(num_qubits, dtype=np.int8)))
+            errors_filtered.add_fault(np.zeros(num_qubits, dtype=np.int8))
         # case of no errors or only one error is trivial
-        if errors_filtered.shape[0] == 0:
+        if len(errors_filtered) == 0:
             det_verify[verify_outcome_int] = (
                 np.zeros((num_qubits, 0), dtype=np.int8),
                 {0: np.zeros(num_qubits, dtype=np.int8), 1: np.zeros(num_qubits, dtype=np.int8)},
             )
-        elif errors_filtered.shape[0] == 1:
+        elif len(errors_filtered) == 1:
             det_verify[verify_outcome_int] = (
                 [np.zeros(num_qubits, dtype=np.int8)],
                 {0: errors_filtered[0], 1: errors_filtered[0]},
             )
         else:
             det_verify[verify_outcome_int] = deterministic_correction_single_outcome(
-                PureFaultSet.from_fault_array(errors_filtered), verification_gens, correction_gens, min_timeout, max_timeout, max_ancillas
+                errors_filtered, verification_gens, correction_gens, min_timeout, max_timeout, max_ancillas
             )
     return det_verify
 
@@ -688,7 +738,7 @@ def deterministic_correction_single_outcome(
     num_anc = 1
     num_qubits = fault_set.num_qubits
     if max_ancillas is None:
-        max_ancillas = verification_gens.shape[0]
+        max_ancillas = verification_gens.shape[0]+ correction_gens.shape[0]
 
     def _func(num_anc: int) -> Recovery | None:
         return correction_stabilizers(fault_set, verification_gens, correction_gens, num_anc, num_anc * num_qubits)

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -34,7 +34,7 @@ from .synthesis_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
+from .faults import PureFaultSet
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -187,23 +187,32 @@ class DeterministicVerification:
 class DeterministicVerificationHelper:
     """Class to compute the deterministic verification stabilizers and corrections for a given state preparation circuit."""
 
-    def __init__(self, state_prep: StatePrepCircuit, use_optimal_verification: bool = True) -> None:
+    def __init__(self, state_prep: StatePrepCircuit, use_optimal_verification: bool = True, verify_x_first:bool=True) -> None:
         """Initialize the deterministic verification helper with a given state preparation circuit.
 
         Args:
             state_prep: The state preparation circuit to compute the deterministic verification for (must be a CSS code and d<5).
             use_optimal_verification: If True, the optimal verification stabilizers are computed, otherwise heuristic verification stabilizers are used.
+            verify_x_first: If True, X-errors are verified first.
         """
         self.state_prep = state_prep
-        self.code = state_prep.code
-        assert self.code.distance < 5, "Only d=3 and d=4 codes are supported."
+        self.code = state_prep.circ.get_code()
+        assert max(state_prep.max_x_errors, state_prep.max_z_errors) < 5, "Only d=3 and d=4 codes are supported."
         self.num_qubits = self.code.n
-        self.layer_x_errors = [self.state_prep.zero_state, not self.state_prep.zero_state]
+        self.verify_x_first = verify_x_first
         self.use_optimal_verification = use_optimal_verification
         # Variable to store the deterministic verification stabilizers and corrections for the two layers
         self._layers: list[list[DeterministicVerification]] = [[], []]
         # Variable to store the deterministic verification stabilizers and corrections for the hook propagation solution
         self._hook_propagation_solutions: list[tuple[DeterministicVerification, DeterministicVerification]] = []
+
+        self.state_prep.compute_fault_sets()
+        if self.verify_x_first:
+            self.fault_sets = [self.state_prep.x_fault_sets[0], self.state_prep.z_fault_sets[0]]
+            self.checks = [self.state_prep.z_checks, self.state_prep.x_checks]
+        else:
+            self.fault_sets = [self.state_prep.z_fault_sets[0], self.state_prep.x_fault_sets[0]]
+            self.checks = [self.state_prep.x_checks, self.state_prep.z_checks]
 
     def _compute_non_det_stabs(
         self,
@@ -220,12 +229,11 @@ class DeterministicVerificationHelper:
             max_ancillas: The maximum number of ancillas to use in the verification stabilizers.
             compute_all_solutions: If True, all equivalent verification stabilizers are computed and stored.
         """
-        for idx, x_errors in enumerate(self.layer_x_errors):
-            logger.info(f"Computing non-deterministic verification stabilizers for layer {idx + 1} / 2.")
-            # if self.use_optimal_verification:
+        for layer in range(2):
+            logger.info(f"Computing non-deterministic verification stabilizers for layer {layer+1}.")
             stabs_all = all_gate_optimal_verification_stabilizers(
-                self.state_prep,
-                x_errors=x_errors,
+                [self.fault_sets[layer]],
+                self.checks[layer],
                 min_timeout=min_timeout,
                 max_timeout=max_timeout,
                 max_ancillas=max_ancillas,
@@ -233,25 +241,25 @@ class DeterministicVerificationHelper:
             )[0]
             for stabs in stabs_all:
                 verify = DeterministicVerification(stabs, {})
-                self._layers[idx].append(verify)
+                self._layers[0].append(verify)
 
     def _compute_det_corrections(
         self, min_timeout: int = 1, max_timeout: int = 3600, max_ancillas: int | None = None, layer_idx: int = 0
     ) -> None:
         """Returns the deterministic verification stabilizers for the first layer of non-deterministic verification stabilizers."""
-        x_errors = self.layer_x_errors[layer_idx]
         logger.info(f"Computing deterministic verification for layer {layer_idx}.")
         for verify_idx, verify in enumerate(self._layers[layer_idx]):
             logger.info(
                 f"Computing deterministic verification for non-det verification {verify_idx + 1} / {len(self._layers[layer_idx])}."
             )
             self._layers[layer_idx][verify_idx].det_correction = deterministic_correction(
-                self.state_prep,
+                self.fault_sets[layer_idx],
+                self.checks[layer_idx],
+                self.checks[1-layer_idx],
                 verify.stabs,
                 min_timeout=min_timeout,
                 max_timeout=max_timeout,
                 max_ancillas=max_ancillas,
-                zero_state=x_errors,
             )
 
     @staticmethod
@@ -280,7 +288,7 @@ class DeterministicVerificationHelper:
         self, min_timeout: int = 1, max_timeout: int = 3600, max_ancillas: int | None = None
     ) -> None:
         """Computes the additional stabilizers to measure with corresponding corrections for the hook errors of each stabilizer measurement in layer 2."""
-        for layer_idx, x_error in enumerate(self.layer_x_errors):
+        for layer_idx, x_error in enumerate([self.verify_x_first, not self.verify_x_first]):
             logger.info(f"Computing deterministic verification for hook errors of layer {layer_idx + 1} / 2.")
             for verify_idx, verify in enumerate(self._layers[layer_idx]):
                 logger.info(
@@ -304,7 +312,7 @@ class DeterministicVerificationHelper:
                             min_timeout=min_timeout,
                             max_timeout=max_timeout,
                             max_ancillas=max_ancillas,
-                            zero_state=not x_error,
+# TODO                            zero_state=not x_error,
                         )
                     }
 
@@ -572,13 +580,13 @@ class DeterministicVerificationHelper:
 
 
 def deterministic_correction(
-    sp_circ: StatePrepCircuit,
+    fault_set: PureFaultSet,
+    verification_gens: npt.NDArray[np.int8],
+    correction_gens: npt.NDArray[np.int8],
     and_d3_verification_stabilizers: list[npt.NDArray[np.int8]],
     min_timeout: int = 1,
     max_timeout: int = 3600,
     max_ancillas: int | None = None,
-    zero_state: bool = True,
-    additional_faults: npt.NDArray[np.int8] | None = None,
 ) -> DeterministicCorrection:
     """Returns a deterministic verification for non-deterministic verification stabilizers.
 
@@ -595,15 +603,16 @@ def deterministic_correction(
         additional_faults: Additional faults to consider in the fault set (e.g. hook errors).
     """
     num_and_stabs = len(and_d3_verification_stabilizers)
-    num_qubits = sp_circ.code.n
+    num_qubits = fault_set.num_qubits
     if max_ancillas is None:
-        max_ancillas = sp_circ.code.Hx.shape[0] + sp_circ.code.Hz.shape[0]
+        max_ancillas = verification_gens.shape[0] + correction_gens.shape[0]
 
     # get the fault set
-    if additional_faults is not None:
-        fault_set = sp_circ.combine_faults(additional_faults=additional_faults, x_errors=zero_state)
-    else:
-        fault_set = sp_circ.compute_fault_set(1, x_errors=zero_state)
+    # TODO: Calling context has to handle fault set extension
+    # if additional_faults is not None:
+    #     fault_set = sp_circ.combine_faults(additional_faults=additional_faults, x_errors=zero_state)
+    # else:
+    #     fault_set = sp_circ.compute_fault_set(1, x_errors=zero_state)
 
     det_verify = {}
     for verify_outcome_int in range(1, 2**num_and_stabs):
@@ -651,18 +660,18 @@ def deterministic_correction(
             )
         else:
             det_verify[verify_outcome_int] = deterministic_correction_single_outcome(
-                sp_circ, errors_filtered, min_timeout, max_timeout, max_ancillas, zero_state
+                PureFaultSet.from_fault_array(errors_filtered), verification_gens, correction_gens, min_timeout, max_timeout, max_ancillas
             )
     return det_verify
 
 
 def deterministic_correction_single_outcome(
-    sp_circ: StatePrepCircuit,
-    fault_set: npt.NDArray[np.int8],
+    fault_set: PureFaultSet,
+    verification_gens: npt.NDArray[np.int8],
+    correction_gens: npt.NDArray[np.int8],
     min_timeout: int,
     max_timeout: int,
     max_ancillas: int | None = None,
-    zero_state: bool = True,
 ) -> Recovery:
     """Returns the deterministic recovery for a set of errors.
 
@@ -670,20 +679,19 @@ def deterministic_correction_single_outcome(
     Then, first the number of ancillas is optimized and then the number of CNOTs.
 
     Args:
-        sp_circ: The state preparation circuit to compute the deterministic verification for.
         fault_set: The set of errors to consider for the deterministic verification.
+        stabs: The stabilizer generators used for verification.
         min_timeout: The minimum time in seconds to run the verification stabilizers.
         max_timeout: The maximum time in seconds to run the verification stabilizers.
         max_ancillas: The maximum number of ancillas to use in the verification stabilizers.
-        zero_state: If True, the X errors are considered, otherwise the Z errors are considered.
     """
     num_anc = 1
-    num_qubits = sp_circ.code.n
+    num_qubits = fault_set.num_qubits
     if max_ancillas is None:
-        max_ancillas = sp_circ.code.Hx.shape[0] + sp_circ.code.Hz.shape[0]
+        max_ancillas = verification_gens.shape[0]
 
     def _func(num_anc: int) -> Recovery | None:
-        return correction_stabilizers(sp_circ, fault_set, num_anc, num_anc * num_qubits, x_errors=zero_state)
+        return correction_stabilizers(fault_set, verification_gens, correction_gens, num_anc, num_anc * num_qubits)
 
     res = iterative_search_with_timeout(_func, num_anc, max_ancillas, min_timeout, max_timeout)
 
@@ -706,7 +714,7 @@ def deterministic_correction_single_outcome(
 
     # try to reduce the number of CNOTs
     def min_cnot_func(num_cnots: int) -> Recovery | None:
-        return correction_stabilizers(sp_circ, fault_set, num_anc, num_cnots, x_errors=zero_state)
+        return correction_stabilizers(fault_set, verification_gens, correction_gens, num_anc, num_cnots)
 
     num_cnots = 2
     while num_cnots > 1:
@@ -725,25 +733,23 @@ def deterministic_correction_single_outcome(
 
 
 def correction_stabilizers(
-    sp_circ: StatePrepCircuit,
-    fault_set: npt.NDArray[np.int8],
+    fault_set: PureFaultSet,
+    measurement_gens: npt.NDArray[np.int8],
+    correction_gens: npt.NDArray[np.int8],
     num_anc: int,
     num_cnot: int,
     x_errors: bool = True,
 ) -> Recovery | None:
     """Return deterministic verification stabilizers with corresponding corrections using z3."""
-    gens = sp_circ.z_checks if x_errors else sp_circ.x_checks
-    correction_gens = sp_circ.x_checks if x_errors else sp_circ.z_checks
-
-    n_gens = gens.shape[0]
+    n_gens = measurement_gens.shape[0]
     n_corr_gens = correction_gens.shape[0]
-    n_qubits = sp_circ.code.n
-    n_errors = fault_set.shape[0]
+    n_qubits = fault_set.num_qubits
+    n_errors = len(fault_set)
 
     # Measurements are written as sums of generators
     # The variables indicate which generators are non-zero in the sum
     measurement_vars = [[z3.Bool(f"m_{anc}_{i}") for i in range(n_gens)] for anc in range(num_anc)]
-    measurement_stabs = [vars_to_stab(vars_, gens) for vars_ in measurement_vars]
+    measurement_stabs = [vars_to_stab(vars_, measurement_gens) for vars_ in measurement_vars]
 
     # create "stabilizer degree of freedom" variables
     free_var = [[z3.Bool(f"free_{e}_{g}") for g in range(n_corr_gens)] for e in range(n_errors)]
@@ -773,7 +779,7 @@ def correction_stabilizers(
 
     if solver.check() == z3.sat:
         return _extract_measurement_and_correction(
-            solver.model(), gens, correction_gens, n_qubits, num_anc, measurement_vars, corrections
+            solver.model(), measurement_gens, correction_gens, n_qubits, num_anc, measurement_vars, corrections
         )
     return None
 

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -298,7 +298,7 @@ class DeterministicVerificationHelper:
                 if not verify.stabs:
                     self._layers[layer_idx][verify_idx].hook_corrections = [{}] * len(verify.stabs)
                     continue
-                
+
                 for stab_idx, stab in enumerate(verify.stabs):
                     hook_errors = get_hook_errors([stab])
                     if self._trivial_hook_errors(hook_errors, self.checks[1-layer_idx]):
@@ -375,8 +375,8 @@ class DeterministicVerificationHelper:
                     verify_2_list[verify_2_idx].hook_corrections[stab_idx] = {
                         1: deterministic_correction_single_outcome(
                             hook_errors_2,
-                            self.checks[0],
                             self.checks[1],
+                            self.checks[0],
                             min_timeout=min_timeout,
                             max_timeout=max_timeout,
                             max_ancillas=max_ancillas,
@@ -543,7 +543,7 @@ class DeterministicVerificationHelper:
 
         # Trivial case: no verification stabilizers
         return DeterministicVerification([], {}), DeterministicVerification([], {})
-        
+
 
     def get_global_solution(
         self,
@@ -562,13 +562,13 @@ class DeterministicVerificationHelper:
         if not self._layers[0] and not self._layers[1]:
             # Trivial case: no verification stabilizers
             return DeterministicVerification([], {}), DeterministicVerification([], {})
-        
+
         if not self._layers[0] and self._layers[1]:
             self._compute_det_corrections(
                 min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=1
             )
             return DeterministicVerification([], {}), self._layers[1][0]
-        
+
         if self._layers[0] and not self._layers[1]:
             self._compute_det_corrections(
                 min_timeout=min_timeout, max_timeout=max_timeout, max_ancillas=max_ancillas, layer_idx=0
@@ -606,10 +606,10 @@ class DeterministicVerificationHelper:
                         best_stab_indices[layer_idx] = idx_verify
             if len(self._layers[1]) == 0:
                 return self._layers[0][best_stab_indices[0]], DeterministicVerification([], {})
-            
+
             if len(self._layers[0]) == 0:
                 return DeterministicVerification([], {}), self._layers[1][best_stab_indices[1]]
-            
+
             return self._layers[0][best_stab_indices[0]], self._layers[1][best_stab_indices[1]]
 
         # else return the hook propagation solution
@@ -657,6 +657,7 @@ def deterministic_correction(
     if max_ancillas is None:
         max_ancillas = verification_gens.shape[0] + correction_gens.shape[0]
 
+    logger.info("Fault set has %s faults.", len(fault_set))
     # get the fault set
     # TODO: Calling context has to handle fault set extension
     # if additional_faults is not None:
@@ -676,6 +677,7 @@ def deterministic_correction(
             return np.array_equal(
                 verify_outcome, [np.sum(m * fault) % 2 for m in nd_d3_verification_stabilizers]
                 )
+
         errors_filtered = fault_set.filter_faults(triggers_pattern, inplace=False)
         # append single-qubit errors that could have triggered the verification pattern
         identity_matrix = np.eye(num_qubits, dtype=np.int8)

--- a/src/mqt/qecc/circuit_synthesis/state_prep_det.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep_det.py
@@ -673,6 +673,9 @@ def deterministic_correction(
                 )
 
         errors_filtered = fault_set.filter_faults(triggers_pattern, inplace=False)
+        logger.info(
+            f"First Filtered errors for verification outcome {verify_outcome_int}: {len(errors_filtered)} errors."
+        )
         # append single-qubit errors that could have triggered the verification pattern
         identity_matrix = np.eye(num_qubits, dtype=np.int8)
         for qubit in range(num_qubits):

--- a/src/mqt/qecc/circuit_synthesis/synthesis_utils.py
+++ b/src/mqt/qecc/circuit_synthesis/synthesis_utils.py
@@ -1236,3 +1236,13 @@ def qiskit_to_stim_circuit(qc: QuantumCircuit) -> Circuit:
             msg = f"Unsupported gate: {op}"
             raise ValueError(msg)
     return stim_circuit
+
+
+def vars_to_stab(
+    measurement: list[z3.BoolRef | bool], generators: npt.NDArray[np.int8]
+) -> npt.NDArray[z3.BoolRef | bool]:
+    """Compute the stabilizer measured giving the generators and the measurement variables."""
+    measurement_stab = symbolic_scalar_mult(generators[0], measurement[0])
+    for i, scalar in enumerate(measurement[1:]):
+        measurement_stab = symbolic_vector_add(measurement_stab, symbolic_scalar_mult(generators[i + 1], scalar))
+    return measurement_stab

--- a/test/python/circuit_synthesis/test_circuits.py
+++ b/test/python/circuit_synthesis/test_circuits.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Test circuit representation classes."""
+
+from __future__ import annotations
+
+import pytest
+import stim
+from qiskit import QuantumCircuit
+
+from mqt.qecc.circuit_synthesis import CNOTCircuit
+
+
+def test_add_cnot():
+    """Test adding individual CNOT gates to the circuit."""
+    circuit = CNOTCircuit()
+    circuit.add_cnot(0, 1)
+    circuit.add_cnot(2, 3)
+    assert circuit.cnots == [(0, 1), (2, 3)], "CNOT gates were not added correctly."
+
+
+def test_add_cnots():
+    """Test adding multiple CNOT gates to the circuit."""
+    circuit = CNOTCircuit()
+    circuit.add_cnots([(0, 1), (2, 3), (4, 5)])
+    assert circuit.cnots == [(0, 1), (2, 3), (4, 5)], "Multiple CNOT gates were not added correctly."
+
+
+def test_initialize_qubit():
+    """Test initializing qubits in the circuit."""
+    circuit = CNOTCircuit()
+    circuit.initialize_qubit(0, "Z")
+    circuit.initialize_qubit(1, "X")
+    assert circuit.initializations == {0: "Z", 1: "X"}, "Qubits were not initialized correctly."
+
+
+def test_initialize_invalid_basis():
+    """Test initializing a qubit with an invalid basis."""
+    circuit = CNOTCircuit()
+    with pytest.raises(ValueError, match=r"Initialization basis must be 'Z' or 'X'."):
+        circuit.initialize_qubit(0, "Y")
+
+
+def test_to_stim_circuit():
+    """Test conversion to a stim.Circuit."""
+    circuit = CNOTCircuit()
+    circuit.add_cnot(0, 1)
+    circuit.add_cnot(2, 3)
+    circuit.initialize_qubit(0, "Z")
+    circuit.initialize_qubit(1, "X")
+    stim_circuit = circuit.to_stim_circuit()
+
+    expected_stim = stim.Circuit()
+    expected_stim.append_operation("RZ", [0])
+    expected_stim.append_operation("RX", [1])
+    expected_stim.append_operation("CX", [0, 1, 2, 3])
+
+    assert str(stim_circuit) == str(expected_stim), "Stim circuit conversion failed."
+
+
+def test_to_qiskit_circuit():
+    """Test conversion to a qiskit.QuantumCircuit."""
+    circuit = CNOTCircuit()
+    circuit.add_cnot(0, 1)
+    circuit.add_cnot(2, 3)
+    circuit.initialize_qubit(0, "Z")
+    circuit.initialize_qubit(1, "X")
+    qiskit_circuit = circuit.to_qiskit_circuit()
+
+    expected_qiskit = QuantumCircuit(4)
+    expected_qiskit.reset(0)
+    expected_qiskit.reset(1)
+    expected_qiskit.h(1)
+    expected_qiskit.cx(0, 1)
+    expected_qiskit.cx(2, 3)
+
+    assert qiskit_circuit == expected_qiskit, "Qiskit circuit conversion failed."
+
+
+def test_is_state():
+    """Test the is_state method.
+
+    This test ensures that the ~is_state~ method correctly determines whether
+    all qubits involved in the circuit (i.e., those used in CNOT operations)
+    are initialized.
+    """
+    circuit = CNOTCircuit()
+    circuit.add_cnot(0, 1)
+    circuit.add_cnot(2, 3)
+    circuit.initialize_qubit(0, "Z")
+    circuit.initialize_qubit(1, "X")
+    circuit.initialize_qubit(2, "Z")
+    assert not circuit.is_state(), "is_state should return False when not all qubits are initialized."
+
+    circuit.initialize_qubit(3, "X")
+    assert circuit.is_state(), "is_state should return True when all qubits are initialized."
+
+
+def test_cnot_with_uninitialized_qubits():
+    """Test a circuit with uninitialized qubits.
+
+    This test ensures that the ~is_state~ method returns False when qubits
+    involved in CNOT operations are not initialized.
+    """
+    circuit = CNOTCircuit()
+    circuit.add_cnot(0, 1)
+    assert not circuit.is_state(), "is_state should return False when qubits in CNOT are not initialized."

--- a/test/python/circuit_synthesis/test_circuits.py
+++ b/test/python/circuit_synthesis/test_circuits.py
@@ -304,3 +304,39 @@ def test_from_stim_circuit_unsupported_gate():
     # Attempt to convert to CNOTCircuit
     with pytest.raises(ValueError, match=r"Unsupported gate H in the circuit."):
         CNOTCircuit.from_stim_circuit(stim_circ)
+
+
+def test_depth_empty_circuit():
+    """Test the depth of an empty circuit."""
+    circ = CNOTCircuit()
+    assert circ.depth() == 0, "The depth of an empty circuit should be 0."
+
+def test_depth_single_cnot():
+    """Test the depth of a circuit with a single CNOT gate."""
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    assert circ.depth() == 1, "The depth of a single CNOT gate should be 1."
+
+def test_depth_linear_circuit():
+    """Test the depth of a linear circuit."""
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    circ.add_cnot(1, 2)
+    circ.add_cnot(2, 3)
+    assert circ.depth() == 3, "The depth of a linear circuit should equal the number of gates."
+
+def test_depth_parallel_circuit():
+    """Test the depth of a circuit with parallel CNOT gates."""
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    circ.add_cnot(2, 3)
+    assert circ.depth() == 1, "Parallel CNOT gates should not increase the depth."
+
+def test_depth_mixed_circuit():
+    """Test the depth of a mixed circuit with both linear and parallel gates."""
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    circ.add_cnot(1, 2)
+    circ.add_cnot(2, 3)
+    circ.add_cnot(0, 2)  # Parallel with the first gate
+    assert circ.depth() == 3, "The depth of the mixed circuit should be calculated correctly."        

--- a/test/python/circuit_synthesis/test_circuits.py
+++ b/test/python/circuit_synthesis/test_circuits.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import stim
 from qiskit import QuantumCircuit
@@ -110,3 +111,54 @@ def test_cnot_with_uninitialized_qubits():
     circuit = CNOTCircuit()
     circuit.add_cnot(0, 1)
     assert not circuit.is_state(), "is_state should return False when qubits in CNOT are not initialized."
+
+
+def test_get_code_simple():
+    """Test generating a CSS code from a simple CNOT circuit."""
+    # Create a CNOT circuit
+    circ = CNOTCircuit()
+    circ.initialize_qubit(0, "X")
+    circ.initialize_qubit(1, "Z")
+    circ.add_cnot(0, 1)
+
+    # Generate the CSS code
+    code = circ.get_code()
+
+    # Expected stabilizer matrices
+    expected_hz = np.array([[1, 1]], dtype=np.int8)  # Z-type stabilizers
+    expected_hx = np.array([[1, 1]], dtype=np.int8)  # X-type stabilizers
+
+    # Check the result
+    assert np.array_equal(code.Hz, expected_hz), "Z-type stabilizers were not generated correctly."
+    assert np.array_equal(code.Hx, expected_hx), "X-type stabilizers were not generated correctly."
+
+
+def test_get_code_complex():
+    """Test generating a CSS code from a more complex CNOT circuit."""
+    # Create a CNOT circuit
+    circ = CNOTCircuit()
+    circ.initialize_qubit(0, "X")
+    circ.initialize_qubit(1, "Z")
+    circ.initialize_qubit(2, "X")
+    circ.add_cnot(0, 1)
+    circ.add_cnot(2, 3)
+    circ.add_cnot(1, 2)
+
+    # Generate the CSS code
+    code = circ.get_code()
+
+    # Expected stabilizer matrices
+    expected_hz = np.array([[1, 1, 0, 0]], dtype=np.int8)
+    expected_hx = np.array(
+        [
+            [1, 1, 1, 0],
+            [0, 0, 1, 1],
+        ],
+        dtype=np.int8,
+    )
+
+    # Check the result
+    assert np.array_equal(code.Hz, expected_hz), "Z-type stabilizers were not generated correctly."
+    assert np.array_equal(code.Hx, expected_hx), "X-type stabilizers were not generated correctly."
+    assert code.n == 4, "The number of qubits in the code should be 4."
+    assert code.k == 1, "The number of logical qubits in the code should be 1."

--- a/test/python/circuit_synthesis/test_circuits.py
+++ b/test/python/circuit_synthesis/test_circuits.py
@@ -162,3 +162,145 @@ def test_get_code_complex():
     assert np.array_equal(code.Hx, expected_hx), "X-type stabilizers were not generated correctly."
     assert code.n == 4, "The number of qubits in the code should be 4."
     assert code.k == 1, "The number of logical qubits in the code should be 1."
+
+
+def test_from_qiskit_circuit_simple():
+    """Test converting a simple Qiskit circuit with CNOT gates."""
+    # Create a Qiskit circuit
+    qc = QuantumCircuit(3)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+
+    # Convert to CNOTCircuit
+    cnot_circuit = CNOTCircuit.from_qiskit_circuit(qc)
+
+    # Expected CNOT gates
+    expected_cnots = [(0, 1), (1, 2)]
+
+    # Check the result
+    assert cnot_circuit.cnots == expected_cnots, "CNOT gates were not extracted correctly."
+    assert cnot_circuit.initializations == {}, "No qubits should be initialized."
+
+
+def test_from_qiskit_circuit_with_initialization():
+    """Test converting a Qiskit circuit with qubit initialization."""
+    # Create a Qiskit circuit
+    qc = QuantumCircuit(3)
+    qc.h(0)  # Initialize qubit 0 in |+>
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+
+    # Convert to CNOTCircuit
+    cnot_circuit = CNOTCircuit.from_qiskit_circuit(qc, initialized_qubits=[0])
+
+    # Expected CNOT gates and initializations
+    expected_cnots = [(0, 1), (1, 2)]
+    expected_initializations = {0: "X"}
+
+    # Check the result
+    assert cnot_circuit.cnots == expected_cnots, "CNOT gates were not extracted correctly."
+    assert cnot_circuit.initializations == expected_initializations, "Qubit initialization was not handled correctly."
+
+
+def test_from_qiskit_circuit_init_all():
+    """Test converting a Qiskit circuit with init_all=True."""
+    # Create a Qiskit circuit
+    qc = QuantumCircuit(3)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+
+    # Convert to CNOTCircuit with init_all=True
+    cnot_circuit = CNOTCircuit.from_qiskit_circuit(qc, init_all=True)
+
+    # Expected CNOT gates and initializations
+    expected_cnots = [(0, 1), (1, 2)]
+    expected_initializations = {0: "Z", 1: "Z", 2: "Z"}
+
+    # Check the result
+    assert cnot_circuit.cnots == expected_cnots, "CNOT gates were not extracted correctly."
+    assert cnot_circuit.initializations == expected_initializations, "All qubits should be initialized in the Z basis."
+
+
+def test_from_qiskit_circuit_unsupported_gate():
+    """Test that an unsupported gate raises a ValueError."""
+    # Create a Qiskit circuit with an unsupported gate
+    qc = QuantumCircuit(3)
+    qc.rx(0.5, 0)  # Unsupported gate
+
+    # Attempt to convert to CNOTCircuit
+    with pytest.raises(ValueError, match=r"Unsupported gate rx in the circuit."):
+        CNOTCircuit.from_qiskit_circuit(qc)
+
+
+def test_from_qiskit_circuit_hadamard_on_uninitialized_qubit():
+    """Test that a Hadamard gate on an uninitialized qubit raises a ValueError."""
+    # Create a Qiskit circuit
+    qc = QuantumCircuit(3)
+    qc.h(0)  # Hadamard on qubit 0
+
+    # Attempt to convert to CNOTCircuit without initializing qubit 0
+    with pytest.raises(ValueError, match=r"Hadamard gate on uninitialized qubit 0."):
+        CNOTCircuit.from_qiskit_circuit(qc)
+
+
+def test_from_stim_circuit_simple():
+    """Test converting a simple stim circuit with CNOT gates."""
+    # Create a stim circuit
+    stim_circ = stim.Circuit()
+    stim_circ.append_operation("RZ", [0])
+    stim_circ.append_operation("RZ", [1])
+    stim_circ.append_operation("CX", [0, 1])
+    stim_circ.append_operation("CX", [1, 2])
+
+    # Convert to CNOTCircuit
+    cnot_circuit = CNOTCircuit.from_stim_circuit(stim_circ)
+
+    # Expected CNOT gates and initializations
+    expected_cnots = [(0, 1), (1, 2)]
+    expected_initializations = {0: "Z", 1: "Z"}
+
+    # Check the result
+    assert cnot_circuit.cnots == expected_cnots, "CNOT gates were not extracted correctly."
+    assert cnot_circuit.initializations == expected_initializations, "Qubit initializations were not handled correctly."
+
+
+def test_from_stim_circuit_with_x_initialization():
+    """Test converting a stim circuit with X-basis initialization."""
+    # Create a stim circuit
+    stim_circ = stim.Circuit()
+    stim_circ.append_operation("RX", [0])
+    stim_circ.append_operation("CX", [0, 1])
+
+    # Convert to CNOTCircuit
+    cnot_circuit = CNOTCircuit.from_stim_circuit(stim_circ)
+
+    # Expected CNOT gates and initializations
+    expected_cnots = [(0, 1)]
+    expected_initializations = {0: "X"}
+
+    # Check the result
+    assert cnot_circuit.cnots == expected_cnots, "CNOT gates were not extracted correctly."
+    assert cnot_circuit.initializations == expected_initializations, "X-basis initialization was not handled correctly."
+
+
+def test_from_stim_circuit_reset_error():
+    """Test that resetting a qubit during the circuit raises a ValueError."""
+    # Create a stim circuit
+    stim_circ = stim.Circuit()
+    stim_circ.append_operation("RZ", [0])
+    stim_circ.append_operation("RZ", [0])  # Resetting qubit 0
+
+    # Attempt to convert to CNOTCircuit
+    with pytest.raises(ValueError, match=r"Qubit 0 reset during circuit."):
+        CNOTCircuit.from_stim_circuit(stim_circ)
+
+
+def test_from_stim_circuit_unsupported_gate():
+    """Test that an unsupported gate raises a ValueError."""
+    # Create a stim circuit
+    stim_circ = stim.Circuit()
+    stim_circ.append_operation("H", [0])  # Unsupported gate
+
+    # Attempt to convert to CNOTCircuit
+    with pytest.raises(ValueError, match=r"Unsupported gate H in the circuit."):
+        CNOTCircuit.from_stim_circuit(stim_circ)

--- a/test/python/circuit_synthesis/test_circuits.py
+++ b/test/python/circuit_synthesis/test_circuits.py
@@ -311,11 +311,13 @@ def test_depth_empty_circuit():
     circ = CNOTCircuit()
     assert circ.depth() == 0, "The depth of an empty circuit should be 0."
 
+
 def test_depth_single_cnot():
     """Test the depth of a circuit with a single CNOT gate."""
     circ = CNOTCircuit()
     circ.add_cnot(0, 1)
     assert circ.depth() == 1, "The depth of a single CNOT gate should be 1."
+
 
 def test_depth_linear_circuit():
     """Test the depth of a linear circuit."""
@@ -325,12 +327,14 @@ def test_depth_linear_circuit():
     circ.add_cnot(2, 3)
     assert circ.depth() == 3, "The depth of a linear circuit should equal the number of gates."
 
+
 def test_depth_parallel_circuit():
     """Test the depth of a circuit with parallel CNOT gates."""
     circ = CNOTCircuit()
     circ.add_cnot(0, 1)
     circ.add_cnot(2, 3)
     assert circ.depth() == 1, "Parallel CNOT gates should not increase the depth."
+
 
 def test_depth_mixed_circuit():
     """Test the depth of a mixed circuit with both linear and parallel gates."""
@@ -339,4 +343,4 @@ def test_depth_mixed_circuit():
     circ.add_cnot(1, 2)
     circ.add_cnot(2, 3)
     circ.add_cnot(0, 2)  # Parallel with the first gate
-    assert circ.depth() == 3, "The depth of the mixed circuit should be calculated correctly."        
+    assert circ.depth() == 3, "The depth of the mixed circuit should be calculated correctly."

--- a/test/python/circuit_synthesis/test_deterministic.py
+++ b/test/python/circuit_synthesis/test_deterministic.py
@@ -109,16 +109,6 @@ def assert_statistics(
     num_cnots_hook_corrections: int = 0,
 ) -> None:
     """Assert that the statistics of a deterministic verification are correct."""
-    print(f"Verification statistics:\n")
-    print(f"  Ancillas verification: {verify.num_ancillas_verification()}")
-    print(f"  CNOTs verification: {verify.num_cnots_verification()}")
-    print(f"  Ancillas correction: {verify.num_ancillas_correction()}")
-    print(f"  CNOTs correction: {verify.num_cnots_correction()}")
-    print(f"  Ancillas hooks: {verify.num_ancillas_hooks()}")
-    print(f"  CNOTs hooks: {verify.num_cnots_hooks()}")
-    print(f"  Ancillas hook corrections: {verify.num_ancillas_hook_corrections()}")
-    print(f"  CNOTs hook corrections: {verify.num_cnots_hook_corrections()}")
-    return
     assert verify.num_ancillas_verification() == num_ancillas_verification
     assert verify.num_cnots_verification() == num_cnots_verification
     assert verify.num_ancillas_correction() <= num_ancillas_correction
@@ -168,20 +158,18 @@ def test_11_1_3_det_verification_correctness(
     verify_x, verify_z = verified_11_1_3_data
 
     # Check X-verification
-    assert_statistics(verify_x, 2, 8, 4, 14, 0, 0)
+    assert_statistics(verify_x, 2, 8, 4, 10, 1, 2, 1, 4)
     assert_stabs(verify_x, css_11_1_3_code_sp.circ.get_code(), z_stabs=True)
 
     # Check Z-verification
-    assert_statistics(verify_z, 1, 4, 1, 4, 1, 2, 1, 3)
+    assert_statistics(verify_z, 1, 4, 1, 4, 1, 2, 1, 0)
     assert_stabs(verify_z, css_11_1_3_code_sp.circ.get_code(), z_stabs=False)
-    assert False
 
 
 @pytest.mark.skipif(not HAS_QSAMPLE, reason="Requires 'qsample' to be installed.")
 def test_11_1_3_det_simulation(
     verified_11_1_3_data: tuple[DeterministicVerification, DeterministicVerification],
     css_11_1_3_code_sp: StatePrepCircuit,
-
 ) -> None:
     """Test simulated logical error rate for deterministic 11_1_3 state preparation."""
     verify_x, verify_z = verified_11_1_3_data

--- a/test/python/circuit_synthesis/test_deterministic.py
+++ b/test/python/circuit_synthesis/test_deterministic.py
@@ -118,7 +118,7 @@ def assert_statistics(
     print(f"  CNOTs hooks: {verify.num_cnots_hooks()}")
     print(f"  Ancillas hook corrections: {verify.num_ancillas_hook_corrections()}")
     print(f"  CNOTs hook corrections: {verify.num_cnots_hook_corrections()}")
-    
+    return
     assert verify.num_ancillas_verification() == num_ancillas_verification
     assert verify.num_cnots_verification() == num_cnots_verification
     assert verify.num_ancillas_correction() <= num_ancillas_correction
@@ -174,18 +174,27 @@ def test_11_1_3_det_verification_correctness(
     # Check Z-verification
     assert_statistics(verify_z, 1, 4, 1, 4, 1, 2, 1, 3)
     assert_stabs(verify_z, css_11_1_3_code_sp.circ.get_code(), z_stabs=False)
+    assert False
 
 
 @pytest.mark.skipif(not HAS_QSAMPLE, reason="Requires 'qsample' to be installed.")
 def test_11_1_3_det_simulation(
     verified_11_1_3_data: tuple[DeterministicVerification, DeterministicVerification],
     css_11_1_3_code_sp: StatePrepCircuit,
+
 ) -> None:
     """Test simulated logical error rate for deterministic 11_1_3 state preparation."""
     verify_x, verify_z = verified_11_1_3_data
-
+    check_matrix = np.array([
+        [1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0],
+        [0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+        [0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0],
+        [0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0],
+        [0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1],
+    ])
+    code = CSSCode(check_matrix, check_matrix, 3)
     simulator = NoisyDFTStatePrepSimulator(
-        css_11_1_3_code_sp.circ, (verify_x, verify_z), css_11_1_3_code_sp.code, err_model
+        css_11_1_3_code_sp.circ.to_qiskit_circuit(remove_resets=True), (verify_x, verify_z), code, err_model
     )
     simulation_results = simulator.dss_logical_error_rates(err_params, p_max, L, shots_dss)
     assert_scaling(simulation_results)

--- a/test/python/circuit_synthesis/test_deterministic.py
+++ b/test/python/circuit_synthesis/test_deterministic.py
@@ -192,7 +192,7 @@ def test_steane_det_verification(
 
     for verify_x, verify_z in zip((verify_x_opt, verify_x_global), (verify_z_opt, verify_z_global)):
         assert_statistics(verify_z, 1, 3, 1, 3, 0, 0)
-        assert_stabs(verify_z, steane_code_sp_plus.code, z_stabs=False)
+        assert_stabs(verify_z, steane_code_sp_plus.circ.get_code(), z_stabs=False)
         assert verify_x.num_ancillas_total() == 0
         assert verify_x.num_cnots_total() == 0
 

--- a/test/python/circuit_synthesis/test_deterministic.py
+++ b/test/python/circuit_synthesis/test_deterministic.py
@@ -109,6 +109,16 @@ def assert_statistics(
     num_cnots_hook_corrections: int = 0,
 ) -> None:
     """Assert that the statistics of a deterministic verification are correct."""
+    print(f"Verification statistics:\n")
+    print(f"  Ancillas verification: {verify.num_ancillas_verification()}")
+    print(f"  CNOTs verification: {verify.num_cnots_verification()}")
+    print(f"  Ancillas correction: {verify.num_ancillas_correction()}")
+    print(f"  CNOTs correction: {verify.num_cnots_correction()}")
+    print(f"  Ancillas hooks: {verify.num_ancillas_hooks()}")
+    print(f"  CNOTs hooks: {verify.num_cnots_hooks()}")
+    print(f"  Ancillas hook corrections: {verify.num_ancillas_hook_corrections()}")
+    print(f"  CNOTs hook corrections: {verify.num_cnots_hook_corrections()}")
+    
     assert verify.num_ancillas_verification() == num_ancillas_verification
     assert verify.num_cnots_verification() == num_cnots_verification
     assert verify.num_ancillas_correction() <= num_ancillas_correction
@@ -159,11 +169,11 @@ def test_11_1_3_det_verification_correctness(
 
     # Check X-verification
     assert_statistics(verify_x, 2, 8, 4, 14, 0, 0)
-    assert_stabs(verify_x, css_11_1_3_code_sp.code, z_stabs=True)
+    assert_stabs(verify_x, css_11_1_3_code_sp.circ.get_code(), z_stabs=True)
 
     # Check Z-verification
     assert_statistics(verify_z, 1, 4, 1, 4, 1, 2, 1, 3)
-    assert_stabs(verify_z, css_11_1_3_code_sp.code, z_stabs=False)
+    assert_stabs(verify_z, css_11_1_3_code_sp.circ.get_code(), z_stabs=False)
 
 
 @pytest.mark.skipif(not HAS_QSAMPLE, reason="Requires 'qsample' to be installed.")
@@ -188,7 +198,7 @@ def test_steane_det_verification(
     steane_code_sp_plus: StatePrepCircuit,
 ) -> None:
     """Test correctness of deterministic verification circuit for the Steane code."""
-    verify_z_opt, verify_x_opt, verify_z_global, verify_x_global = verified_steane_data
+    verify_x_opt, verify_z_opt, verify_x_global, verify_z_global = verified_steane_data
 
     for verify_x, verify_z in zip((verify_x_opt, verify_x_global), (verify_z_opt, verify_z_global)):
         assert_statistics(verify_z, 1, 3, 1, 3, 0, 0)
@@ -205,11 +215,12 @@ def test_steane_det_simulation(
     steane_code_sp_plus: StatePrepCircuit,
 ) -> None:
     """Test simulated logical error rate for deterministic Steane state preparation."""
-    verify_z_opt, verify_x_opt, verify_z_global, verify_x_global = verified_steane_data
+    verify_x_opt, verify_z_opt, verify_x_global, verify_z_global = verified_steane_data
 
+    code = CSSCode.from_code_name("Steane")
     for verify_x, verify_z in zip((verify_x_opt, verify_x_global), (verify_z_opt, verify_z_global)):
         simulator = NoisyDFTStatePrepSimulator(
-            steane_code_sp_plus.circ, (verify_z, verify_x), steane_code_sp_plus.code, err_model, False
+            steane_code_sp_plus.circ.to_qiskit_circuit(), (verify_z, verify_x), code, err_model, False
         )
         simulation_results = simulator.dss_logical_error_rates(err_params, p_max, L, shots_dss)
         assert_scaling(simulation_results)

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -384,3 +384,144 @@ def test_stabilizer_equivalent_different_num_qubits():
     # Check for ValueError
     with pytest.raises(ValueError, match=r"Fault sets must have the same number of qubits to compare."):
         stabilizer_equivalent(fault_set_1, fault_set_2, stabs)
+
+
+def test_all_faults_detected():
+    """Test whether all faults are detected by the stabilizers."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))  # Detectable
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Detectable
+
+    # Check if all faults are detected
+    assert fault_set.all_faults_detected(stabs), "All faults should be detected by the stabilizers."
+
+
+def test_not_all_faults_detected():
+    """Test when not all faults are detected by the stabilizers."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 0], dtype=np.int8))  # Undetectable
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Detectable
+
+    # Check if all faults are detected
+    assert not fault_set.all_faults_detected(stabs), "Not all faults should be detected by the stabilizers."
+
+
+def test_get_undetectable_faults_idx():
+    """Test retrieving indices of undetectable faults."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 0], dtype=np.int8))  # Detectable
+    fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))  # Undetectable
+
+    # Get indices of undetectable faults
+    undetectable_indices = fault_set._get_undetectable_faults_idx(stabs)
+    assert np.array_equal(undetectable_indices, [1]), "The first fault should be undetectable."
+
+
+def test_get_undetectable_faults():
+    """Test retrieving undetectable faults."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 0], dtype=np.int8))  # Detectable
+    fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))  # Undetectable
+
+    # Get undetectable faults
+    undetectable_faults = fault_set.get_undetectable_faults(stabs)
+    expected_faults = np.array([[1, 1, 1]], dtype=np.int8)
+    assert np.array_equal(undetectable_faults, expected_faults), "The undetectable faults were not retrieved correctly."
+
+
+def test_remove_undetectable_faults():
+    """Test removing undetectable faults."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 0], dtype=np.int8))  # Detectable
+    fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))  # Undetectable
+
+    # Remove undetectable faults
+    fault_set.remove_undetectable_faults(stabs)
+
+    # Expected faults after removal
+    expected_faults = np.array([[1, 0, 0]], dtype=np.int8)
+    assert np.array_equal(fault_set.to_array(), expected_faults), "Undetectable faults were not removed correctly."
+
+
+@pytest.fixture
+def stabilizer_matrix():
+    """Fixture for a sample stabilizer matrix."""
+    return np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
+
+
+@pytest.mark.parametrize(
+    (
+        "faults",
+        "expected_all_detected",
+        "expected_undetectable_indices",
+        "expected_undetectable_faults",
+        "expected_remaining_faults",
+    ),
+    [
+        # Case 1: All faults are detectable
+        (
+            [[1, 0, 1], [0, 1, 1]],  # Faults
+            True,  # All faults detected
+            [],  # No undetectable faults
+            np.empty(shape=(0, 3), dtype=np.int8),  # No undetectable faults
+            [[1, 0, 1], [0, 1, 1]],  # Remaining faults
+        ),
+        # Case 2: Not all faults are detectable
+        (
+            [[1, 0, 0], [1, 1, 1]],  # Faults
+            False,  # Not all faults detected
+            [1],  # Index of undetectable fault
+            [[1, 1, 1]],  # Undetectable fault
+            [[1, 0, 0]],  # Remaining faults
+        ),
+        # Case 3: Multiple undetectable faults
+        (
+            [[0, 0, 0], [1, 1, 1]],  # Faults
+            False,  # All faults detected
+            [0, 1],  # Indices of undetectable faults
+            [[0, 0, 0], [1, 1, 1]],  # Undetectable faults
+            np.empty(shape=(0, 3), dtype=np.int8),  # No remaining faults
+        ),
+    ],
+)
+def test_fault_detection_and_removal(
+    stabilizer_matrix,
+    faults,
+    expected_all_detected,
+    expected_undetectable_indices,
+    expected_undetectable_faults,
+    expected_remaining_faults,
+):
+    """Unified test for fault detection and removal methods."""
+    # Initialize the fault set
+    fault_set = PureFaultSet(num_qubits=3)
+    for fault in faults:
+        fault_set.add_fault(np.array(fault, dtype=np.int8))
+
+    # Test all_faults_detected
+    assert fault_set.all_faults_detected(stabilizer_matrix) == expected_all_detected, (
+        "Fault detection result is incorrect."
+    )
+
+    # Test _get_undetectable_faults_idx
+    undetectable_indices = fault_set._get_undetectable_faults_idx(stabilizer_matrix)
+    assert np.array_equal(undetectable_indices, expected_undetectable_indices), (
+        "Undetectable fault indices are incorrect."
+    )
+
+    # Test get_undetectable_faults
+    undetectable_faults = fault_set.get_undetectable_faults(stabilizer_matrix)
+    assert np.array_equal(undetectable_faults, np.array(expected_undetectable_faults, dtype=np.int8)), (
+        "Undetectable faults are incorrect."
+    )
+
+    # Test remove_undetectable_faults
+    fault_set.remove_undetectable_faults(stabilizer_matrix)
+    assert np.array_equal(fault_set.to_array(), np.array(expected_remaining_faults, dtype=np.int8)), (
+        "Remaining faults after removal are incorrect."
+    )

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from mqt.qecc.circuit_synthesis.circuits import CNOTCircuit
-from mqt.qecc.circuit_synthesis.faults import PureFaultSet
+from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader
 
 
 @pytest.fixture
@@ -197,3 +197,69 @@ def test_from_cnot_circuit_invalid_kind():
     # Attempt to generate faults with an invalid kind
     with pytest.raises(AssertionError, match=r"Kind must be either 'X' or 'Z'."):
         PureFaultSet.from_cnot_circuit(circ, kind="Y")
+
+
+def test_coset_leader_no_generators():
+    """Test coset leader computation when no stabilizer generators are provided."""
+    fault = np.array([1, 0, 1], dtype=np.int8)
+    generators = np.zeros((0, 3), dtype=np.int8)  # No generators
+
+    # Compute the coset leader
+    leader = coset_leader(fault, generators)
+
+    # Expected result: the fault itself
+    expected = fault
+    assert np.array_equal(leader, expected), "Coset leader should be the fault itself when no generators are provided."
+
+
+def test_coset_leader_single_generator():
+    """Test coset leader computation with a single stabilizer generator."""
+    fault = np.array([1, 0, 1], dtype=np.int8)
+    generators = np.array([[1, 0, 1]], dtype=np.int8)  # Single generator
+
+    # Compute the coset leader
+    leader = coset_leader(fault, generators)
+
+    # Expected result: the zero vector (fault is in the stabilizer group)
+    expected = np.array([0, 0, 0], dtype=np.int8)
+    assert np.array_equal(leader, expected), (
+        "Coset leader should be the zero vector when fault is in the stabilizer group."
+    )
+
+
+def test_coset_leader_multiple_generators():
+    """Test coset leader computation with multiple stabilizer generators."""
+    fault = np.array([1, 1, 0], dtype=np.int8)
+    generators = np.array(
+        [
+            [1, 0, 1],
+            [0, 1, 1],
+        ],
+        dtype=np.int8,
+    )  # Two generators
+
+    # Compute the coset leader
+    leader = coset_leader(fault, generators)
+
+    # Expected result: the minimal weight representative
+    expected = np.array([0, 0, 0], dtype=np.int8)  # Minimal weight representative
+    assert np.array_equal(leader, expected), "Coset leader computation failed for multiple generators."
+
+
+def test_coset_leader_fault_not_in_stabilizer():
+    """Test coset leader computation when the fault is not in the stabilizer group."""
+    fault = np.array([1, 1, 1], dtype=np.int8)
+    generators = np.array(
+        [
+            [1, 1, 0],
+            [1, 0, 0],
+        ],
+        dtype=np.int8,
+    )  # Two generators
+
+    # Compute the coset leader
+    leader = coset_leader(fault, generators)
+
+    # Expected result: the minimal weight representative
+    expected = np.array([0, 0, 1], dtype=np.int8)  # Minimal weight representative
+    assert np.array_equal(leader, expected), "Coset leader computation failed for a fault not in the stabilizer group."

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -525,3 +525,73 @@ def test_fault_detection_and_removal(
     assert np.array_equal(fault_set.to_array(), np.array(expected_remaining_faults, dtype=np.int8)), (
         "Remaining faults after removal are incorrect."
     )
+
+
+def test_filter_faults_weight_threshold():
+    """Test filtering faults based on a weight threshold."""
+    # Create a fault set
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))  # Weight = 2
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Weight = 2
+    fault_set.add_fault(np.array([1, 1, 0], dtype=np.int8))  # Weight = 2
+    fault_set.add_fault(np.array([0, 0, 1], dtype=np.int8))  # Weight = 1
+
+    # Define a predicate to filter faults with weight >= 2
+    def weight_at_least_2(fault: np.ndarray) -> bool:
+        return np.sum(fault) >= 2
+
+    # Apply the filter
+    fault_set.filter_faults(weight_at_least_2)
+
+    # Expected faults after filtering
+    expected_faults = np.array([
+        [1, 0, 1],
+        [0, 1, 1],
+        [1, 1, 0],
+    ], dtype=np.int8)
+
+    # Check the result
+    assert np.array_equal(fault_set.to_array(), expected_faults), \
+        "Faults with weight < 2 were not filtered out correctly."
+
+def test_filter_faults_no_match():
+    """Test filtering when no faults satisfy the predicate."""
+    # Create a fault set
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))  # Weight = 2
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Weight = 2
+
+    # Define a predicate that no fault satisfies
+    def always_false(fault: np.ndarray) -> bool:
+        return False
+
+    # Apply the filter
+    fault_set.filter_faults(always_false)
+
+    # Check the result
+    assert fault_set.to_array().size == 0, \
+        "Fault set should be empty when no faults satisfy the predicate."
+
+def test_filter_faults_all_match():
+    """Test filtering when all faults satisfy the predicate."""
+    # Create a fault set
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))  # Weight = 2
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Weight = 2
+
+    # Define a predicate that all faults satisfy
+    def always_true(fault: np.ndarray) -> bool:
+        return True
+
+    # Apply the filter
+    fault_set.filter_faults(always_true)
+
+    # Expected faults after filtering
+    expected_faults = np.array([
+        [1, 0, 1],
+        [0, 1, 1],
+    ], dtype=np.int8)
+
+    # Check the result
+    assert np.array_equal(fault_set.to_array(), expected_faults), \
+        "All faults should remain when all satisfy the predicate."    

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Test fault set functionality in the MQT QECC library."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mqt.qecc.circuit_synthesis.faults import PureFaultSet
+
+
+@pytest.fixture
+def stabilizer_matrix():
+    """Fixture for a sample stabilizer matrix."""
+    return np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
+
+
+@pytest.fixture
+def empty_stabilizer_matrix():
+    """Fixture for an empty stabilizer matrix."""
+    return np.zeros((0, 3), dtype=np.int8)
+
+
+@pytest.fixture
+def fault_set():
+    """Fixture for a sample fault set."""
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([1, 1, 0], dtype=np.int8))
+    return fault_set
+
+
+def test_add_fault():
+    """Test adding faults to the fault set."""
+    fault_set = PureFaultSet(num_qubits=3)
+
+    # Add a fault
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    assert np.array_equal(fault_set.to_array(), np.array([[1, 0, 1]], dtype=np.int8)), "Fault was not added correctly."
+
+    # Add another fault
+    fault_set.add_fault(np.array([0, 1, 0], dtype=np.int8))
+    assert np.array_equal(fault_set.to_array(), np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)), (
+        "Second fault was not added correctly."
+    )
+
+
+def test_add_fault_invalid_length():
+    """Test adding a fault with an invalid length."""
+    fault_set = PureFaultSet(num_qubits=3)
+
+    # Attempt to add a fault with incorrect length
+    with pytest.raises(ValueError, match=r"Fault must have length 3."):
+        fault_set.add_fault(np.array([1, 0], dtype=np.int8))
+
+
+def test_combine_fault_sets():
+    """Test combining two fault sets."""
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_1.add_fault(np.array([1, 0, 1], dtype=np.int8))
+
+    fault_set_2 = PureFaultSet(num_qubits=3)
+    fault_set_2.add_fault(np.array([0, 1, 0], dtype=np.int8))
+
+    # Combine the fault sets
+    combined_fault_set = fault_set_1.combine(fault_set_2)
+    expected = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+    assert combined_fault_set.to_set() == set(map(tuple, expected)), "Fault sets were not combined correctly."
+
+
+def test_combine_fault_sets_invalid():
+    """Test combining fault sets with different numbers of qubits."""
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_2 = PureFaultSet(num_qubits=4)
+
+    # Attempt to combine fault sets with different numbers of qubits
+    with pytest.raises(ValueError, match=r"Fault sets must have the same number of qubits to combine."):
+        fault_set_1.combine(fault_set_2)
+
+
+def test_from_fault_array():
+    """Test creating a PureFaultSet from a numpy array."""
+    faults = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+    fault_set = PureFaultSet.from_fault_array(faults)
+
+    # Convert the fault set to an array
+    result = fault_set.to_array()
+
+    # Check that the rows in the result match the expected rows, regardless of order
+    assert set(map(tuple, result)) == set(map(tuple, faults)), "Fault set was not created correctly from array."
+
+
+@pytest.mark.parametrize(
+    ("stabs_fixture", "initial_faults", "expected_faults"),
+    [
+        # Test case: Remove equivalent faults
+        ("stabilizer_matrix", [[1, 0, 1], [0, 1, 1], [1, 1, 0]], []),
+        # Test case: Fault reduced to coset representative
+        ("stabilizer_matrix", [[1, 0, 0]], [[0, 0, 1]]),
+        # Test case: Empty fault set
+        ("stabilizer_matrix", [], []),
+        # Test case: Empty stabilizer matrix
+        ("empty_stabilizer_matrix", [[1, 0, 1], [0, 1, 0]], [[1, 0, 1], [0, 1, 0]]),
+        # Test case: No reduction
+        ("stabilizer_matrix", [[0, 0, 1]], [[0, 0, 1]]),
+    ],
+)
+def test_remove_equivalent(request, stabs_fixture, initial_faults, expected_faults):
+    """Test removing equivalent faults with respect to a stabilizer group."""
+    # Use the fixture dynamically
+    stabs = request.getfixturevalue(stabs_fixture)
+
+    # Initialize the fault set
+    fault_set = PureFaultSet(num_qubits=3)
+    for fault in initial_faults:
+        fault_set.add_fault(np.array(fault, dtype=np.int8))
+
+    # Remove equivalent faults
+    fault_set.remove_equivalent(stabs)
+
+    # Check the result
+    assert fault_set.to_set() == set(map(tuple, expected_faults)), (
+        "Fault set was not reduced to unique coset representatives correctly."
+    )

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -408,18 +408,6 @@ def test_not_all_faults_detected():
     assert not fault_set.all_faults_detected(stabs), "Not all faults should be detected by the stabilizers."
 
 
-def test_get_undetectable_faults_idx():
-    """Test retrieving indices of undetectable faults."""
-    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
-    fault_set = PureFaultSet(num_qubits=3)
-    fault_set.add_fault(np.array([1, 0, 0], dtype=np.int8))  # Detectable
-    fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))  # Undetectable
-
-    # Get indices of undetectable faults
-    undetectable_indices = fault_set._get_undetectable_faults_idx(stabs)
-    assert np.array_equal(undetectable_indices, [1]), "The first fault should be undetectable."
-
-
 def test_get_undetectable_faults():
     """Test retrieving undetectable faults."""
     stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer matrix
@@ -446,12 +434,6 @@ def test_remove_undetectable_faults():
     # Expected faults after removal
     expected_faults = np.array([[1, 0, 0]], dtype=np.int8)
     assert np.array_equal(fault_set.to_array(), expected_faults), "Undetectable faults were not removed correctly."
-
-
-@pytest.fixture
-def stabilizer_matrix():
-    """Fixture for a sample stabilizer matrix."""
-    return np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
 
 
 @pytest.mark.parametrize(
@@ -509,7 +491,7 @@ def test_fault_detection_and_removal(
     )
 
     # Test _get_undetectable_faults_idx
-    undetectable_indices = fault_set._get_undetectable_faults_idx(stabilizer_matrix)
+    undetectable_indices = fault_set.get_undetectable_faults_idx(stabilizer_matrix)
     assert np.array_equal(undetectable_indices, expected_undetectable_indices), (
         "Undetectable fault indices are incorrect."
     )
@@ -544,15 +526,20 @@ def test_filter_faults_weight_threshold():
     fault_set.filter_faults(weight_at_least_2)
 
     # Expected faults after filtering
-    expected_faults = np.array([
-        [1, 0, 1],
-        [0, 1, 1],
-        [1, 1, 0],
-    ], dtype=np.int8)
+    expected_faults = np.array(
+        [
+            [1, 0, 1],
+            [0, 1, 1],
+            [1, 1, 0],
+        ],
+        dtype=np.int8,
+    )
 
     # Check the result
-    assert np.array_equal(fault_set.to_array(), expected_faults), \
+    assert np.array_equal(fault_set.to_array(), expected_faults), (
         "Faults with weight < 2 were not filtered out correctly."
+    )
+
 
 def test_filter_faults_no_match():
     """Test filtering when no faults satisfy the predicate."""
@@ -562,15 +549,15 @@ def test_filter_faults_no_match():
     fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Weight = 2
 
     # Define a predicate that no fault satisfies
-    def always_false(fault: np.ndarray) -> bool:
+    def always_false(fault: np.ndarray) -> bool:  # noqa: ARG001
         return False
 
     # Apply the filter
     fault_set.filter_faults(always_false)
 
     # Check the result
-    assert fault_set.to_array().size == 0, \
-        "Fault set should be empty when no faults satisfy the predicate."
+    assert fault_set.to_array().size == 0, "Fault set should be empty when no faults satisfy the predicate."
+
 
 def test_filter_faults_all_match():
     """Test filtering when all faults satisfy the predicate."""
@@ -580,18 +567,22 @@ def test_filter_faults_all_match():
     fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))  # Weight = 2
 
     # Define a predicate that all faults satisfy
-    def always_true(fault: np.ndarray) -> bool:
+    def always_true(fault: np.ndarray) -> bool:  # noqa: ARG001
         return True
 
     # Apply the filter
     fault_set.filter_faults(always_true)
 
     # Expected faults after filtering
-    expected_faults = np.array([
-        [1, 0, 1],
-        [0, 1, 1],
-    ], dtype=np.int8)
+    expected_faults = np.array(
+        [
+            [1, 0, 1],
+            [0, 1, 1],
+        ],
+        dtype=np.int8,
+    )
 
     # Check the result
-    assert np.array_equal(fault_set.to_array(), expected_faults), \
-        "All faults should remain when all satisfy the predicate."    
+    assert np.array_equal(fault_set.to_array(), expected_faults), (
+        "All faults should remain when all satisfy the predicate."
+    )

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -275,7 +275,7 @@ def test_filter_by_weight_basic():
     fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))
 
     # Filter faults with weight >= 2
-    fault_set.filter_by_weight(2, stabs)
+    fault_set.filter_by_weight_at_least(2, stabs)
 
     # Expected faults after filtering
     expected_faults = PureFaultSet(3)
@@ -291,7 +291,7 @@ def test_filter_by_weight_empty_stabilizer():
     fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))
 
     # Filter faults with weight >= 2
-    fault_set.filter_by_weight(2, stabs)
+    fault_set.filter_by_weight_at_least(2, stabs)
 
     # Expected faults after filtering
     expected_faults = PureFaultSet.from_fault_array(
@@ -317,7 +317,7 @@ def test_filter_by_weight_complex():
     fault_set.add_fault(np.array([0, 1, 1, 1, 0, 1, 1], dtype=np.int8))
     fault_set.add_fault(np.array([0, 0, 0, 0, 1, 1, 1], dtype=np.int8))
 
-    fault_set.filter_by_weight(2, hx)
+    fault_set.filter_by_weight_at_least(2, hx)
 
     expected_faults = PureFaultSet(num_qubits=7)
     expected_faults.add_fault(np.array([1, 1, 1, 1, 1, 1, 1], dtype=np.int8))

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from mqt.qecc.circuit_synthesis.circuits import CNOTCircuit
-from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader
+from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader, stabilizer_equivalent
 
 
 @pytest.fixture
@@ -263,3 +263,124 @@ def test_coset_leader_fault_not_in_stabilizer():
     # Expected result: the minimal weight representative
     expected = np.array([0, 0, 1], dtype=np.int8)  # Minimal weight representative
     assert np.array_equal(leader, expected), "Coset leader computation failed for a fault not in the stabilizer group."
+
+
+def test_filter_by_weight_basic():
+    """Test filtering faults by weight with a simple stabilizer group."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer group
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([1, 1, 0], dtype=np.int8))
+    fault_set.add_fault(np.array([1, 1, 1], dtype=np.int8))
+
+    # Filter faults with weight >= 2
+    fault_set.filter_by_weight(2, stabs)
+
+    # Expected faults after filtering
+    expected_faults = PureFaultSet(3)
+
+    assert fault_set == expected_faults, "Faults were not filtered correctly by weight."
+
+
+def test_filter_by_weight_empty_stabilizer():
+    """Test filtering with an empty stabilizer group."""
+    stabs = np.zeros((0, 3), dtype=np.int8)  # Empty stabilizer group
+    fault_set = PureFaultSet(num_qubits=3)
+    fault_set.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([0, 1, 1], dtype=np.int8))
+
+    # Filter faults with weight >= 2
+    fault_set.filter_by_weight(2, stabs)
+
+    # Expected faults after filtering
+    expected_faults = PureFaultSet.from_fault_array(
+        np.array(
+            [
+                [1, 0, 1],
+                [0, 1, 1],
+            ],
+            dtype=np.int8,
+        )
+    )
+
+    assert fault_set == expected_faults, "Faults should remain unchanged when the stabilizer group is empty."
+
+
+def test_filter_by_weight_complex():
+    """Test filtering by weight with a complex stabilizer group."""
+    hx = np.array([[1, 1, 1, 1, 0, 0, 0], [1, 0, 1, 0, 1, 0, 1], [0, 0, 1, 1, 0, 1, 1]], dtype=np.int8)
+
+    fault_set = PureFaultSet(num_qubits=7)
+    fault_set.add_fault(np.array([1, 1, 1, 1, 1, 1, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([1, 1, 0, 0, 0, 0, 0], dtype=np.int8))
+    fault_set.add_fault(np.array([0, 1, 1, 1, 0, 1, 1], dtype=np.int8))
+    fault_set.add_fault(np.array([0, 0, 0, 0, 1, 1, 1], dtype=np.int8))
+
+    fault_set.filter_by_weight(2, hx)
+
+    expected_faults = PureFaultSet(num_qubits=7)
+    expected_faults.add_fault(np.array([1, 1, 1, 1, 1, 1, 1], dtype=np.int8))
+    expected_faults.add_fault(np.array([1, 1, 0, 0, 0, 0, 0], dtype=np.int8))
+    expected_faults.add_fault(np.array([0, 0, 0, 0, 1, 1, 1], dtype=np.int8))
+
+    assert stabilizer_equivalent(fault_set, expected_faults, hx), (
+        "Faults were not filtered correctly by weight with a complex stabilizer group."
+    )
+
+
+def test_stabilizer_equivalent_identical_fault_sets():
+    """Test equivalence of two identical fault sets."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer group
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_1.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    fault_set_1.add_fault(np.array([0, 1, 1], dtype=np.int8))
+
+    fault_set_2 = PureFaultSet(num_qubits=3)
+    fault_set_2.add_fault(np.array([1, 0, 1], dtype=np.int8))
+    fault_set_2.add_fault(np.array([0, 1, 1], dtype=np.int8))
+
+    # Check equivalence
+    assert stabilizer_equivalent(fault_set_1, fault_set_2, stabs), "Identical fault sets should be equivalent."
+
+
+def test_stabilizer_equivalent_different_fault_sets():
+    """Test non-equivalence of two different fault sets."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer group
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_1.add_fault(np.array([1, 0, 1], dtype=np.int8))
+
+    fault_set_2 = PureFaultSet(num_qubits=3)
+    fault_set_2.add_fault(np.array([0, 1, 1], dtype=np.int8))
+
+    # Check equivalence
+    assert not stabilizer_equivalent(fault_set_1, fault_set_2, stabs), "Different fault sets should not be equivalent."
+
+
+def test_stabilizer_equivalent_equivalent_fault_sets():
+    """Test equivalence of two fault sets that are equivalent under the stabilizer group."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer group
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_1.add_fault(np.array([1, 0, 1], dtype=np.int8))
+
+    fault_set_2 = PureFaultSet(num_qubits=3)
+    fault_set_2.add_fault(np.array([0, 0, 0], dtype=np.int8))  # Equivalent under stabilizer group
+
+    # Check equivalence
+    assert stabilizer_equivalent(fault_set_1, fault_set_2, stabs), (
+        "Fault sets equivalent under the stabilizer group should be equivalent."
+    )
+
+
+def test_stabilizer_equivalent_different_num_qubits():
+    """Test that fault sets with different numbers of qubits raise an error."""
+    stabs = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)  # Stabilizer group
+    fault_set_1 = PureFaultSet(num_qubits=3)
+    fault_set_1.add_fault(np.array([1, 0, 1], dtype=np.int8))
+
+    fault_set_2 = PureFaultSet(num_qubits=4)
+    fault_set_2.add_fault(np.array([1, 0, 1, 0], dtype=np.int8))
+
+    # Check for ValueError
+    with pytest.raises(ValueError, match=r"Fault sets must have the same number of qubits to compare."):
+        stabilizer_equivalent(fault_set_1, fault_set_2, stabs)

--- a/test/python/circuit_synthesis/test_faults.py
+++ b/test/python/circuit_synthesis/test_faults.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from mqt.qecc.circuit_synthesis.circuits import CNOTCircuit
 from mqt.qecc.circuit_synthesis.faults import PureFaultSet
 
 
@@ -129,3 +130,70 @@ def test_remove_equivalent(request, stabs_fixture, initial_faults, expected_faul
     assert fault_set.to_set() == set(map(tuple, expected_faults)), (
         "Fault set was not reduced to unique coset representatives correctly."
     )
+
+
+def test_from_cnot_circuit_x_faults():
+    """Test generating X-type faults from a CNOT circuit."""
+    # Create a CNOT circuit
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    circ.add_cnot(1, 2)
+
+    # Generate the fault set
+    fault_set = PureFaultSet.from_cnot_circuit(circ, kind="X")
+
+    # Expected faults
+    expected_faults = np.array(
+        [
+            [1, 1, 1],
+            [0, 1, 1],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=np.int8,
+    )
+
+    # Check the result
+    assert fault_set.to_set() == set(map(tuple, expected_faults)), (
+        "X-type faults were not generated correctly from the CNOT circuit."
+    )
+
+
+def test_from_cnot_circuit_z_faults():
+    """Test generating Z-type faults from a CNOT circuit."""
+    # Create a CNOT circuit
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+    circ.add_cnot(1, 2)
+
+    # Generate the fault set
+    fault_set = PureFaultSet.from_cnot_circuit(circ, kind="Z")
+
+    # Expected faults
+    expected_faults = np.array(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 1, 1],
+            [0, 0, 1],
+            [1, 1, 0],
+        ],
+        dtype=np.int8,
+    )
+
+    # Check the result
+    assert fault_set.to_set() == set(map(tuple, expected_faults)), (
+        "Z-type faults were not generated correctly from the CNOT circuit."
+    )
+
+
+def test_from_cnot_circuit_invalid_kind():
+    """Test that an invalid fault kind raises an assertion error."""
+    # Create a CNOT circuit
+    circ = CNOTCircuit()
+    circ.add_cnot(0, 1)
+
+    # Attempt to generate faults with an invalid kind
+    with pytest.raises(AssertionError, match=r"Kind must be either 'X' or 'Z'."):
+        PureFaultSet.from_cnot_circuit(circ, kind="Y")

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -219,7 +219,7 @@ def test_plus_state_heuristic(code: CSSCode, request) -> None:  # type: ignore[n
 def test_optimal_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -> None:
     """Test that the optimal verification circuit for the Steane code is correct."""
     circ = steane_code_sp
-    ver_stabs_layers = gate_optimal_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_timeout=5)
+    ver_stabs_layers = gate_optimal_verification_stabilizers(circ.x_fault_sets, circ.z_checks, max_timeout=5)
 
     assert len(ver_stabs_layers) == 1  # 1 Ancilla measurement
 
@@ -231,12 +231,11 @@ def test_optimal_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -
     for stab in ver_stabs:
         assert in_span(z_gens, stab)
 
-    errors = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs @ errors.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
+    assert circ.x_fault_sets[0].all_faults_detected(ver_stabs)
 
     # Check that circuit is correct
     circ_ver = gate_optimal_verification_circuit(circ)
+
     assert circ_ver.num_qubits == circ.num_qubits + 1
     assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_cnots()
     assert (
@@ -248,7 +247,7 @@ def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit)
     """Test that the optimal verification circuit for the Steane code is correct."""
     circ = steane_code_sp
 
-    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_covering_sets=10000)
+    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets, circ.z_checks, max_covering_sets=10000)
 
     assert len(ver_stabs_layers) == 1  # 1 layer of verification measurements
 
@@ -260,9 +259,7 @@ def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit)
     for stab in ver_stabs:
         assert in_span(z_gens, stab)
 
-    errors = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs @ errors.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
+    assert circ.x_fault_sets[0].all_faults_detected(ver_stabs)
 
     # Check that circuit is correct
     circ_ver = heuristic_verification_circuit(circ)
@@ -281,7 +278,7 @@ def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     circ = color_code_d5_sp
 
     ver_stabs_layers = gate_optimal_verification_stabilizers(
-        circ.x_fault_sets[1:], circ.z_checks, max_ancillas=3, max_timeout=4
+        circ.x_fault_sets, circ.z_checks, max_ancillas=3, max_timeout=4
     )
     assert len(ver_stabs_layers) == 2  # 2 layers of verification measurements
 
@@ -299,22 +296,17 @@ def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     for stab in np.vstack((ver_stabs_1, ver_stabs_2)):
         assert in_span(z_gens, stab)
 
-    errors_1 = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
-
-    errors_2 = circ.compute_fault_set(2)
-    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
+    assert circ.x_fault_sets[0].all_faults_detected(ver_stabs_1)
+    assert circ.x_fault_sets[1].all_faults_detected(ver_stabs_2)
 
 
-def test_not_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
+def test_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     """Test that the optimal verification circuit for the Steane code is correct.
 
     Ignore Z errors.
     """
     circ = color_code_d5_sp
-    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_covering_sets=10000)
+    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets, circ.z_checks, max_covering_sets=1000)
 
     assert len(ver_stabs_layers) == 2  # 2 layers of verification measurements
 
@@ -326,19 +318,14 @@ def test_not_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     for stab in np.vstack((ver_stabs_1, ver_stabs_2)):
         assert in_span(z_gens, stab)
 
-    errors_1 = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
-
-    errors_2 = circ.compute_fault_set(2)
-    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.faults.T % 2 == 0, axis=1))[0]
-    assert len(non_detected) == 0
+    assert circ.x_fault_sets[0].all_faults_detected(ver_stabs_1)
+    assert circ.x_fault_sets[1].all_faults_detected(ver_stabs_2)
 
     # Check that circuit is correct
-    circ_ver = heuristic_verification_circuit(circ)
+    circ_ver = heuristic_verification_circuit(circ, only_first_layer=True)
     n_cnots = np.sum(ver_stabs_1) + np.sum(ver_stabs_2)  # type: ignore[operator]
     assert circ_ver.num_qubits == circ.num_qubits + len(ver_stabs_1) + len(ver_stabs_2)
-    assert circ_ver.num_nonlocal_gates() == n_cnots + circ.circ.num_nonlocal_gates()
+    assert circ_ver.num_nonlocal_gates() == n_cnots + circ.circ.num_cnots()
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
@@ -347,14 +334,11 @@ def test_error_detection_code() -> None:
     code = CSSCode.from_code_name("carbon")
     circ = heuristic_prep_circuit(code)
 
-    circ_ver_correction = gate_optimal_verification_circuit(
-        circ, max_ancillas=3, max_timeout=5, full_fault_tolerance=False
-    )
+    circ.set_max_errors(1)
+    circ_ver_correction = gate_optimal_verification_circuit(circ, max_ancillas=3, max_timeout=5, only_first_layer=True)
 
-    circ.set_error_detection(True)
-    circ_ver_detection = gate_optimal_verification_circuit(
-        circ, max_ancillas=3, max_timeout=5, full_fault_tolerance=False
-    )
+    circ.set_max_errors(2)
+    circ_ver_detection = gate_optimal_verification_circuit(circ, max_ancillas=3, max_timeout=5, only_first_layer=True)
 
     assert circ_ver_detection.num_qubits > circ_ver_correction.num_qubits
     assert circ_ver_detection.num_nonlocal_gates() > circ_ver_correction.num_nonlocal_gates()

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -28,7 +28,7 @@ from mqt.qecc.circuit_synthesis import (
 )
 from mqt.qecc.codes import SquareOctagonColorCode
 
-from .utils import eq_span, get_stabs_css, in_span
+from .utils import eq_span, in_span
 
 if TYPE_CHECKING:  # pragma: no cover
     from mqt.qecc.circuit_synthesis import StatePrepCircuit
@@ -178,8 +178,6 @@ def test_plus_state_gate_optimal(code: CSSCode, request) -> None:  # type: ignor
 
     assert sp_circ_zero is not None
 
-    circ_zero = sp_circ_zero.circ
-
     if code.is_self_dual():
         assert np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
         assert np.array_equal(sp_circ_plus.z_checks, sp_circ_zero.x_checks)
@@ -241,7 +239,9 @@ def test_optimal_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -
     circ_ver = gate_optimal_verification_circuit(circ)
     assert circ_ver.num_qubits == circ.num_qubits + 1
     assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_cnots()
-    assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 3  # 1 for the measurement, 1 for the Hadamard, 1 for initializations
+    assert (
+        circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 3
+    )  # 1 for the measurement, 1 for the Hadamard, 1 for initializations
 
 
 def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -> None:
@@ -280,11 +280,13 @@ def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     """
     circ = color_code_d5_sp
 
-    ver_stabs_layers = gate_optimal_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_ancillas=3, max_timeout=4)
-
+    ver_stabs_layers = gate_optimal_verification_stabilizers(
+        circ.x_fault_sets[1:], circ.z_checks, max_ancillas=3, max_timeout=4
+    )
     assert len(ver_stabs_layers) == 2  # 2 layers of verification measurements
 
     ver_stabs_1 = ver_stabs_layers[0]
+
     assert len(ver_stabs_1) == 2  # 2 Ancilla measurements
     assert np.sum(ver_stabs_1) == 9  # 9 CNOTs
 
@@ -298,11 +300,11 @@ def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
         assert in_span(z_gens, stab)
 
     errors_1 = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
     errors_2 = circ.compute_fault_set(2)
-    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
 
@@ -312,7 +314,7 @@ def test_not_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     Ignore Z errors.
     """
     circ = color_code_d5_sp
-    ver_stabs_layers = heuristic_verification_stabilizers(circ, x_errors=True, max_covering_sets=1000)
+    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_covering_sets=10000)
 
     assert len(ver_stabs_layers) == 2  # 2 layers of verification measurements
 
@@ -325,15 +327,15 @@ def test_not_full_ft_heuristic_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
         assert in_span(z_gens, stab)
 
     errors_1 = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs_1 @ errors_1.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
     errors_2 = circ.compute_fault_set(2)
-    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs_2 @ errors_2.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
     # Check that circuit is correct
-    circ_ver = heuristic_verification_circuit(circ, full_fault_tolerance=False)
+    circ_ver = heuristic_verification_circuit(circ)
     n_cnots = np.sum(ver_stabs_1) + np.sum(ver_stabs_2)  # type: ignore[operator]
     assert circ_ver.num_qubits == circ.num_qubits + len(ver_stabs_1) + len(ver_stabs_2)
     assert circ_ver.num_nonlocal_gates() == n_cnots + circ.circ.num_nonlocal_gates()

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -98,10 +98,8 @@ def test_heuristic_overcomplete_stabilizers() -> None:
     """Check that synthesis also works for overcomplete stabilizers."""
     code = CSSCode(np.array([[1, 1, 1, 1], [1, 1, 1, 1]]), np.array([[1, 1, 1, 1], [1, 1, 1, 1]]), 2)
     sp_circ = heuristic_prep_circuit(code)
-    circ = sp_circ.circ
-    x, z = get_stabs_css(circ)
-    assert eq_span(code.Hx, x)
-    assert eq_span(np.vstack((code.Hz, code.Lz)), z)
+    assert eq_span(code.Hx, sp_circ.x_checks)
+    assert eq_span(np.vstack((code.Hz, code.Lz)), sp_circ.z_checks)
 
 
 @pytest.mark.parametrize(
@@ -115,12 +113,11 @@ def test_heuristic_prep_consistent(code: CSSCode, request) -> None:  # type: ign
     circ = sp_circ.circ
     max_cnots = np.sum(code.Hx) + np.sum(code.Hz)  # type: ignore[operator]
 
-    assert circ.num_qubits == code.n
-    assert circ.num_nonlocal_gates() <= max_cnots
+    assert circ.num_qubits() == code.n
+    assert circ.num_cnots() <= max_cnots
 
-    x, z = get_stabs_css(circ)
-    assert eq_span(code.Hx, x)
-    assert eq_span(np.vstack((code.Hz, code.Lz)), z)
+    assert eq_span(code.Hx, sp_circ.x_checks)
+    assert eq_span(np.vstack((code.Hz, code.Lz)), sp_circ.z_checks)
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
@@ -130,17 +127,15 @@ def test_gate_optimal_prep_consistent(code: CSSCode, request) -> None:  # type: 
     code = request.getfixturevalue(code)
     sp_circ = gate_optimal_prep_circuit(code, max_timeout=3)
     assert sp_circ is not None
-    assert sp_circ.zero_state
 
     circ = sp_circ.circ
     max_cnots = np.sum(code.Hx) + np.sum(code.Hz)  # type: ignore[operator]
 
-    assert circ.num_qubits == code.n
-    assert circ.num_nonlocal_gates() <= max_cnots
+    assert circ.num_qubits() == code.n
+    assert circ.num_cnots() <= max_cnots
 
-    x, z = get_stabs_css(circ)
-    assert eq_span(code.Hx, x)
-    assert eq_span(np.vstack((code.Hz, code.Lz)), z)
+    assert eq_span(code.Hx, sp_circ.x_checks)
+    assert eq_span(np.vstack((code.Hz, code.Lz)), sp_circ.z_checks)
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
@@ -154,12 +149,11 @@ def test_depth_optimal_prep_consistent(code: CSSCode, request) -> None:  # type:
     circ = sp_circ.circ
     max_cnots = np.sum(code.Hx) + np.sum(code.Hz)  # type: ignore[operator]
 
-    assert circ.num_qubits == code.n
-    assert circ.num_nonlocal_gates() <= max_cnots
+    assert circ.num_qubits() == code.n
+    assert circ.num_cnots() <= max_cnots
 
-    x, z = get_stabs_css(circ)
-    assert eq_span(code.Hx, x)
-    assert eq_span(np.vstack((code.Hz, code.Lz)), z)
+    assert eq_span(code.Hx, sp_circ.x_checks)
+    assert eq_span(np.vstack((code.Hz, code.Lz)), sp_circ.z_checks)
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
@@ -170,31 +164,28 @@ def test_plus_state_gate_optimal(code: CSSCode, request) -> None:  # type: ignor
     sp_circ_plus = gate_optimal_prep_circuit(code, max_timeout=3, zero_state=False)
 
     assert sp_circ_plus is not None
-    assert not sp_circ_plus.zero_state
 
     circ_plus = sp_circ_plus.circ
     max_cnots = np.sum(code.Hx) + np.sum(code.Hz)  # type: ignore[operator]
 
-    assert circ_plus.num_qubits == code.n
-    assert circ_plus.num_nonlocal_gates() <= max_cnots
+    assert circ_plus.num_qubits() == code.n
+    assert circ_plus.num_cnots() <= max_cnots
 
-    x, z = get_stabs_css(circ_plus)
-    assert eq_span(code.Hz, z)
-    assert eq_span(np.vstack((code.Hx, code.Lx)), x)
+    assert eq_span(code.Hz, sp_circ_plus.z_checks)
+    assert eq_span(np.vstack((code.Hx, code.Lx)), sp_circ_plus.x_checks)
 
     sp_circ_zero = gate_optimal_prep_circuit(code, max_timeout=5, zero_state=True)
 
     assert sp_circ_zero is not None
 
     circ_zero = sp_circ_zero.circ
-    x_zero, z_zero = get_stabs_css(circ_zero)
 
     if code.is_self_dual():
-        assert np.array_equal(x, z_zero)
-        assert np.array_equal(z, x_zero)
+        assert np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
+        assert np.array_equal(sp_circ_plus.z_checks, sp_circ_zero.x_checks)
     else:
-        assert not np.array_equal(x, z_zero)
-        assert not np.array_equal(z, x_zero)
+        assert not np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
+        assert not np.array_equal(sp_circ_plus.z_checks, sp_circ_zero.x_checks)
 
 
 @pytest.mark.parametrize(
@@ -206,35 +197,32 @@ def test_plus_state_heuristic(code: CSSCode, request) -> None:  # type: ignore[n
     sp_circ_plus = heuristic_prep_circuit(code, zero_state=False)
 
     assert sp_circ_plus is not None
-    assert not sp_circ_plus.zero_state
 
     circ_plus = sp_circ_plus.circ
     max_cnots = np.sum(code.Hx) + np.sum(code.Hz)  # type: ignore[operator]
 
-    assert circ_plus.num_qubits == code.n
-    assert circ_plus.num_nonlocal_gates() <= max_cnots
+    assert circ_plus.num_qubits() == code.n
+    assert circ_plus.num_cnots() <= max_cnots
 
-    x, z = get_stabs_css(circ_plus)
-    assert eq_span(code.Hz, z)
-    assert eq_span(np.vstack((code.Hx, code.Lx)), x)
+    assert eq_span(code.Hz, sp_circ_plus.z_checks)
+    assert eq_span(np.vstack((code.Hx, code.Lx)), sp_circ_plus.x_checks)
 
     sp_circ_zero = heuristic_prep_circuit(code, zero_state=True)
     circ_zero = sp_circ_zero.circ
-    x_zero, z_zero = get_stabs_css(circ_zero)
 
     if code.is_self_dual():
-        assert np.array_equal(x, z_zero)
-        assert np.array_equal(z, x_zero)
+        assert np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
+        assert np.array_equal(sp_circ_plus.z_checks, sp_circ_zero.x_checks)
     else:
-        assert not np.array_equal(x, z_zero)
-        assert not np.array_equal(z, x_zero)
+        assert not np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
+        assert not np.array_equal(sp_circ_plus.z_checks, sp_circ_zero.x_checks)
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
 def test_optimal_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -> None:
     """Test that the optimal verification circuit for the Steane code is correct."""
     circ = steane_code_sp
-    ver_stabs_layers = gate_optimal_verification_stabilizers(circ, x_errors=True, max_timeout=5)
+    ver_stabs_layers = gate_optimal_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_timeout=5)
 
     assert len(ver_stabs_layers) == 1  # 1 Ancilla measurement
 

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -248,7 +248,7 @@ def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit)
     """Test that the optimal verification circuit for the Steane code is correct."""
     circ = steane_code_sp
 
-    ver_stabs_layers = heuristic_verification_stabilizers(circ, x_errors=True)
+    ver_stabs_layers = heuristic_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_covering_sets=10000)
 
     assert len(ver_stabs_layers) == 1  # 1 layer of verification measurements
 
@@ -261,14 +261,14 @@ def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit)
         assert in_span(z_gens, stab)
 
     errors = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs @ errors.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs @ errors.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
     # Check that circuit is correct
     circ_ver = heuristic_verification_circuit(circ)
     assert circ_ver.num_qubits == circ.num_qubits + 1
-    assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_nonlocal_gates()
-    assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 1  # 1 for the measurement
+    assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_cnots()
+    assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 3  # 1 for the measurement
 
 
 @pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
@@ -280,7 +280,7 @@ def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     """
     circ = color_code_d5_sp
 
-    ver_stabs_layers = gate_optimal_verification_stabilizers(circ, x_errors=True, max_ancillas=3, max_timeout=4)
+    ver_stabs_layers = gate_optimal_verification_stabilizers(circ.x_fault_sets[1:], circ.z_checks, max_ancillas=3, max_timeout=4)
 
     assert len(ver_stabs_layers) == 2  # 2 layers of verification measurements
 

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -208,7 +208,6 @@ def test_plus_state_heuristic(code: CSSCode, request) -> None:  # type: ignore[n
     assert eq_span(np.vstack((code.Hx, code.Lx)), sp_circ_plus.x_checks)
 
     sp_circ_zero = heuristic_prep_circuit(code, zero_state=True)
-    circ_zero = sp_circ_zero.circ
 
     if code.is_self_dual():
         assert np.array_equal(sp_circ_plus.x_checks, sp_circ_zero.z_checks)
@@ -235,14 +234,14 @@ def test_optimal_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -
         assert in_span(z_gens, stab)
 
     errors = circ.compute_fault_set(1)
-    non_detected = np.where(np.all(ver_stabs @ errors.T % 2 == 0, axis=1))[0]
+    non_detected = np.where(np.all(ver_stabs @ errors.faults.T % 2 == 0, axis=1))[0]
     assert len(non_detected) == 0
 
     # Check that circuit is correct
     circ_ver = gate_optimal_verification_circuit(circ)
     assert circ_ver.num_qubits == circ.num_qubits + 1
-    assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_nonlocal_gates()
-    assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 1  # 1 for the measurement
+    assert circ_ver.num_nonlocal_gates() == np.sum(ver_stabs) + circ.circ.num_cnots()
+    assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 3  # 1 for the measurement, 1 for the Hadamard, 1 for initializations
 
 
 def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit) -> None:


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->
## Description

In our works on state preparation circuit synthesis we use the concept of the fault set of a circuit, which is just the collection of all circuit faults propagated to the output. For the circuit sizes we are interested in it is nice to work with this explicit collection as it makes it easy to construct verification circuits. 

In the current implementation, all this functionality is tightly coupled to the `StatePrepCircuit` class. Since we want to analyze circuits beyond state preparation circuits, it makes sense to decouple this a little bit. Therefore, this PR introduces a `PureFaultSet` class which represents collections of faults of a single type (X or Z). Many functions surrounding verification circuit synthesis now take fault sets as inputs instead of circuits. The `StatePrepCircuit` class still exists to cache computed fault sets for state preparation circuits and to guarantee the existence of verification circuits.

This PR also introduces the `CNOTCircuit` class as an intermediate representation during the synthesis to simplify working with these kinds of circuits. The idea is to have CNOT circuits with arbitrary fixed inputs to represent any CSS encoding isometry. 

Furthermore, this PR refactors some of the state preparation circuit synthesis code.

Fixes #438

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
