### PR TITLE
Fix flaky test fails due to timeouts on macos.

### DIFF
--- a/test/python/circuit_synthesis/test_cat_states.py
+++ b/test/python/circuit_synthesis/test_cat_states.py
@@ -88,7 +88,7 @@ def test_cat_state_experiment_nonft() -> None:
     sim = CatStatePreparationExperiment(c1, c2, perm)
 
     ps = np.arange(0.01, 0.1, 0.01)
-    _, _, errs, _ = sim.cat_prep_experiment(ps, shots_per_p=1000000)
+    _, _, errs, _ = sim.cat_prep_experiment(ps, shots_per_p=2000000)
 
     # In the given circuit structure, single errors can lead to weight 3 errors.
     # Since c1 and c2 prepare the circuit in the same way, such errors cancel out and won't be detected.

--- a/test/python/circuit_synthesis/test_encoder_synthesis.py
+++ b/test/python/circuit_synthesis/test_encoder_synthesis.py
@@ -115,7 +115,10 @@ def test_heuristic_encoding_consistent(code: CSSCode, request) -> None:  # type:
     _assert_correct_encoding_circuit(encoder, encoding_qubits, code)
 
 
-@pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
+@pytest.mark.skipif(
+    os.getenv("CI") is not None and (sys.platform == "win32" or sys.platform == "darwin"),
+    reason="Too slow for CI on Windows or MacOS",
+)
 @pytest.mark.parametrize("code", ["steane_code", "css_4_2_2_code", "css_6_2_2_code"])
 def test_gate_optimal_encoding_consistent(code: CSSCode, request) -> None:  # type: ignore[no-untyped-def]
     """Check that `gate_optimal_encoding_circuit` returns a valid circuit with the correct stabilizers."""

--- a/test/python/circuit_synthesis/test_stateprep.py
+++ b/test/python/circuit_synthesis/test_stateprep.py
@@ -284,7 +284,10 @@ def test_heuristic_steane_verification_circuit(steane_code_sp: StatePrepCircuit)
     assert circ_ver.depth() == np.sum(ver_stabs) + circ.circ.depth() + 1  # 1 for the measurement
 
 
-@pytest.mark.skipif(os.getenv("CI") is not None and sys.platform == "win32", reason="Too slow for CI on Windows")
+@pytest.mark.skipif(
+    os.getenv("CI") is not None and (sys.platform == "win32" or sys.platform == "darwin"),
+    reason="Too slow for CI on Windows or MacOS",
+)
 def test_not_full_ft_opt_cc5(color_code_d5_sp: StatePrepCircuit) -> None:
     """Test that the optimal verification is also correct for higher distance.
 


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

For some reason, lately, the Z3 solver is slower on macOS 13. This PR disables running test cases with harder instances for the Z3 solver on macOS.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
