### PR TITLE
Set maximum ancillas correctly in verification circuit synthesis.

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/state_prep.py
+++ b/src/mqt/qecc/circuit_synthesis/state_prep.py
@@ -353,7 +353,8 @@ def all_gate_optimal_verification_stabilizers(
     """
     n_layers = len(fault_sets)
     layers: list[list[list[npt.NDArray[np.int8]]]] = [[] for _ in range(n_layers)]
-    max_ancillas = stabs.shape[0]
+    if max_ancillas is None:
+        max_ancillas = stabs.shape[0]
 
     # Find the optimal circuit for every number of errors in the preparation circuit
     for layer in range(n_layers):


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

# Description 

The `max_ancillas` parameter was ignored in the verification circuit synthesis. This probably also fixes the flaky tests since the verification circuit synthesis previously built the SAT formula using the most ancillas.
## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
