### PR TITLE
Introduce XZFaultList for tracking X and Z faults simultaneously

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -614,7 +614,7 @@ class XZFaultList:
         Raises:
             ValueError: If control or target indices are out of range or equal.
         """
-        self.ensure_apply_valid_input(control, target)
+        self._ensure_apply_valid_input(control, target)
 
         if inplace:
             # Apply CNOT directly to self.faults
@@ -650,7 +650,7 @@ class XZFaultList:
         Raises:
             ValueError: If qubit index is out of range.
         """
-        self.ensure_apply_valid_input(qubit)
+        self._ensure_apply_valid_input(qubit)
 
         if inplace:
             # Atomic swap using tuple assignment; use copies on RHS to avoid overlap
@@ -688,7 +688,7 @@ class XZFaultList:
         Raises:
             ValueError: If qubit index is out of range.
         """
-        self.ensure_apply_valid_input(qubit)
+        self._ensure_apply_valid_input(qubit)
 
         if inplace:
             self.faults["X"][:, qubit] = 0
@@ -733,7 +733,7 @@ class XZFaultList:
         # We do a simple logic, that every pair of X faults leads, in the worst case, to a Z fault on the other control. So we can just add all pairs of X faults as Z faults.
         # Z_i ^= (X_j & X_k) for all distinct i, j, k in {control1, control2, control3}
 
-        self.ensure_apply_valid_input(control1, control2, control3)
+        self._ensure_apply_valid_input(control1, control2, control3)
 
         if inplace:
             x_faults, z_faults = self.faults["X"], self.faults["Z"]
@@ -767,7 +767,7 @@ class XZFaultList:
             ValueError: If any qubit index is out of range.
             ValueError: If qubits are not distinct.
         """
-        self.ensure_apply_valid_input(control1, control2, target)
+        self._ensure_apply_valid_input(control1, control2, target)
 
         fault_list = self.apply_hadamard(target, inplace=inplace)
         fault_list.apply_ccz(control1, control2, target)
@@ -775,11 +775,11 @@ class XZFaultList:
 
         return fault_list
 
-    def ensure_apply_valid_input(self, *qubits: int) -> bool:
+    def _ensure_apply_valid_input(self, *qubits: int) -> None:
         """Ensures that the input into apply_* functions are valid.
 
         Returns:
-            bool: True if everything is okay
+            None: None if everything is okay
 
         Raises:
             ValueError: If any qubit index is out of range.
@@ -792,8 +792,6 @@ class XZFaultList:
         if n_q > 1 and len(set(qubits)) != n_q:
             msg = "All qubits must be different."
             raise ValueError(msg)
-
-        return True
 
     def reduce_to_coset_leaders(
         self, generators: tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None], inplace: bool = True

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -835,5 +835,5 @@ class XZFaultList:
 
     def __repr__(self) -> str:
         """Return a string representation of the XZFaultList."""
-        repr_ = [object.__repr__(self), "X:", repr(self.faults["X"]), "Z:", repr(self.faults["Z"])]
+        repr_ = [object.__repr__(self) + f" num_qubits: {self.num_qubits}", "X:", repr(self.faults["X"]), "Z:", repr(self.faults["Z"])]
         return "\n".join(repr_)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -818,9 +818,9 @@ class XZFaultList:
         # use qecc_faults.coset_leader(single_fault, generators) for x and z
         ret = self if inplace else self.copy()
 
-        for error_type, g in zip(ret.faults, generators, strict=False):
+        for error_type, _g in zip(ret.faults, generators, strict=False):
             # Ensure generators are numpy arrays (may be empty)
-            g = None if g is None else np.asarray(g, dtype=np.int8)
+            g = None if _g is None else np.asarray(_g, dtype=np.int8)
 
             # Check sizes
             if g is not None and (g.ndim != 2 or g.shape[1] != self.num_qubits):

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -834,5 +834,6 @@ class XZFaultList:
         return ret
 
     def __repr__(self) -> str:
+        """Return a string representation of the XZFaultList."""
         repr_ = [object.__repr__(self), "X:", repr(self.faults["X"]), "Z:", repr(self.faults["Z"])]
         return "\n".join(repr_)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 import numpy as np
 import z3
@@ -483,3 +483,356 @@ def t_distinct(fs1: PureFaultSet, fs2: PureFaultSet, t: int, stabs: npt.NDArray[
                 return False
     # if no solution was found, the fault sets are t-distinct
     return True
+
+
+class XZFaultList():
+    def __init__(self, num_qubits: int) -> None:
+        """Initialise a XZFaultList object
+
+        Args:
+            num_qubits (int): The number of qubits in the circuit
+        """
+        self.num_qubits = num_qubits
+        self.faults = {
+            "X": np.zeros((0, num_qubits), dtype=np.int8),
+            "Z": np.zeros((0, num_qubits), dtype=np.int8),
+        }
+
+    def add_fault(self, faults: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
+        """Add a single fault pair (X error, Z error) to the fault list.
+
+        Args:
+            faults: A tuple of (x_fault, z_fault) where each is a 1D numpy array.
+                Each array must have length num_qubits. 
+                One of the faults may be set to None, which is treated as an all-zero fault.
+
+        Raises:
+            ValueError: If fault arrays don't have the correct length.
+            ValueError: If both faults are None
+        """
+        assert len(faults) == 2, "Faults should be a tuple of x_fault and z_fault"
+
+        x_fault, z_fault = faults
+        if x_fault is None and z_fault is None:
+            raise ValueError("At least one fault must be provided.")
+
+        if x_fault is None:
+            z_fault = np.asarray(z_fault, dtype=np.int8)
+            x_fault = np.zeros(self.num_qubits, dtype=np.int8)
+        elif z_fault is None:
+            x_fault = np.asarray(x_fault, dtype=np.int8)
+            z_fault = np.zeros(self.num_qubits, dtype=np.int8)
+        else:
+            x_fault = np.asarray(x_fault, dtype=np.int8)
+            z_fault = np.asarray(z_fault, dtype=np.int8)
+
+        if x_fault.shape[0] != self.num_qubits or z_fault.shape[0] != self.num_qubits:
+            msg = f"Faults must have length {self.num_qubits}."
+            raise ValueError(msg)
+
+        self.faults["X"] = np.vstack([self.faults["X"], x_fault])
+        self.faults["Z"] = np.vstack([self.faults["Z"], z_fault])
+
+    def add_faults(self, faults: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
+        """Add multiple fault pairs to the fault list.
+
+        Args:
+            faults: A tuple of (x_faults, z_faults) where each is a 2D numpy array.
+                Each array should have num_qubits columns.
+                One of the faults may be set to None, which is treated as an all-zero fault.
+
+        Raises:
+            ValueError: If fault arrays don't have the correct shape.
+            ValueError: If both fault arrays are None
+        """
+        x_faults, z_faults = faults
+        if x_faults is None and z_faults is None:
+            raise ValueError("At least one fault array must be provided.")
+
+        if x_faults is None:
+            z_faults = np.asarray(z_faults, dtype=np.int8)
+            x_faults = np.zeros_like(z_faults, dtype=np.int8)
+        elif z_faults is None:
+            x_faults = np.asarray(x_faults, dtype=np.int8)
+            z_faults = np.zeros_like(x_faults, dtype=np.int8)
+        else:
+            x_faults = np.asarray(x_faults, dtype=np.int8)
+            z_faults = np.asarray(z_faults, dtype=np.int8)
+
+        if x_faults.shape[1] != self.num_qubits or z_faults.shape[1] != self.num_qubits:
+            msg = f"Faults must have {self.num_qubits} columns."
+            raise ValueError(msg)
+
+        self.faults["X"] = np.vstack([self.faults["X"], x_faults])
+        self.faults["Z"] = np.vstack([self.faults["Z"], z_faults])
+
+    def copy(self) -> XZFaultList:
+        """Create a copy of the XZFaultList.
+
+        Returns:
+            A new XZFaultList object with copied fault arrays.
+        """
+        new_list = XZFaultList(self.num_qubits)
+        new_list.faults["X"] = np.copy(self.faults["X"])
+        new_list.faults["Z"] = np.copy(self.faults["Z"])
+        return new_list
+
+    def __iter__(self):
+        """Iterate over fault pairs in the list.
+
+        Yields:
+            Tuples of (x_fault, z_fault) for each row in the fault arrays.
+        """
+        for i in range(len(self.faults["X"])):
+            yield (self.faults["X"][i], self.faults["Z"][i])
+
+    def apply_cnot(self, control: int, target: int, inplace: bool = True) -> XZFaultList:
+        """Apply a CNOT gate to the faults in the list.
+
+        For X-type faults: target qubit is affected by control qubit (target ^= control).
+        For Z-type faults: control qubit is affected by target qubit (control ^= target).
+
+        Args:
+            control: The index of the control qubit.
+            target: The index of the target qubit.
+            inplace: If True, modifies the current fault list. If False, returns a new XZFaultList.
+
+        Returns:
+            A new XZFaultList with updated faults if inplace is False, otherwise self.
+
+        Raises:
+            ValueError: If control or target indices are out of range or equal.
+        """
+        self.ensure_apply_valid_input(control, target)
+
+        if inplace:
+            # Apply CNOT directly to self.faults
+            x_faults, z_faults = self.faults["X"], self.faults["Z"]
+            ret = self
+        else:
+            # Create a new XZFaultList with copied faults
+            new_list = XZFaultList(self.num_qubits)
+            new_list.faults["X"] = np.copy(self.faults["X"])
+            new_list.faults["Z"] = np.copy(self.faults["Z"])
+
+            x_faults, z_faults = new_list.faults["X"], new_list.faults["Z"]
+            ret = new_list
+
+        # Apply CNOT
+        x_faults[:, target]  ^= x_faults[:, control]
+        z_faults[:, control] ^= z_faults[:, target]
+
+        return ret
+
+    def apply_hadamard(self, qubit: int, inplace: bool = True) -> XZFaultList:
+        """Apply a Hadamard gate to the faults in the list.
+
+        A Hadamard gate swaps X and Z errors on the specified qubit.
+
+        Args:
+            qubit: The index of the qubit.
+            inplace: If True, modifies the current fault list. If False, returns a new XZFaultList.
+
+        Returns:
+            A new XZFaultList with updated faults if inplace is False, otherwise self.
+
+        Raises:
+            ValueError: If qubit index is out of range.
+        """
+        self.ensure_apply_valid_input(qubit)
+
+        if inplace:
+            # Atomic swap using tuple assignment; use copies on RHS to avoid overlap
+            self.faults["X"][:, qubit], self.faults["Z"][:, qubit] = (
+                self.faults["Z"][:, qubit].copy(),
+                self.faults["X"][:, qubit].copy(),
+            )
+            return self
+
+        # Create a new XZFaultList with copied and swapped faults
+        new_list = XZFaultList(self.num_qubits)
+        new_list.faults["X"] = np.copy(self.faults["X"])
+        new_list.faults["Z"] = np.copy(self.faults["Z"])
+
+        # Atomic swap on the copies
+        new_list.faults["X"][:, qubit], new_list.faults["Z"][:, qubit] = (
+            new_list.faults["Z"][:, qubit].copy(),
+            new_list.faults["X"][:, qubit].copy(),
+        )
+
+        return new_list
+        
+    def apply_reset(self, qubit: int, inplace: bool = True) -> XZFaultList:
+        """Apply a reset operation to the faults in the list.
+
+        A reset removes any accumulated X and Z errors on the specified qubit.
+
+        Args:
+            qubit: The index of the qubit.
+            inplace: If True, modifies the current fault list. If False, returns a new XZFaultList.
+
+        Returns:
+            A new XZFaultList with updated faults if inplace is False, otherwise self.
+
+        Raises:
+            ValueError: If qubit index is out of range.
+        """
+        self.ensure_apply_valid_input(qubit)
+
+        if inplace:
+            self.faults["X"][:, qubit] = 0
+            self.faults["Z"][:, qubit] = 0
+            return self
+
+        new_list = XZFaultList(self.num_qubits)
+        new_list.faults["X"] = np.copy(self.faults["X"])
+        new_list.faults["Z"] = np.copy(self.faults["Z"])
+        new_list.faults["X"][:, qubit] = 0
+        new_list.faults["Z"][:, qubit] = 0
+        return new_list
+        
+    def apply_ccz(self, control1: int, control2: int, control3: int, inplace: bool = True) -> XZFaultList:
+        """Apply a CCZ gate to the faults in the list.
+
+        The propagation model is adversarial: any pair of X faults on two controls
+        will induce a Z fault on the third control. 
+        We can do this also because the given circuit is assumed to be fault tolerant.
+
+        Note: CCZ is symmetrical, thus there is no "target" per se
+
+        Args:
+            control1: The first control qubit.
+            control2: The second control qubit.
+            control3: The third control qubit.
+            inplace: If True, modifies the current fault list. If False, returns a new XZFaultList.
+
+        Returns:
+            A new XZFaultList with updated faults if inplace is False, otherwise self.
+
+        Raises:
+            ValueError: If any control index is out of range.
+            ValueError: If any control qubits are not distinct.
+        """
+        # Z faults just get propagated through
+        # Only X faults are problematic
+
+        # By right, the state of the qubits matter, which is why you can't simply propagate pauli gates through a CCZ gate.
+
+        # Adverserial Fault Propagation for CCZ:
+        # We do a simple logic, that every pair of X faults leads, in the worst case, to a Z fault on the other control. So we can just add all pairs of X faults as Z faults.
+        # Z_i ^= (X_j & X_k) for all distinct i, j, k in {control1, control2, control3}
+
+        self.ensure_apply_valid_input(control1, control2, control3)
+
+        if inplace:
+            x_faults, z_faults = self.faults["X"], self.faults["Z"]
+            ret = self
+        else:
+            new_list = XZFaultList(self.num_qubits)
+            new_list.faults["X"] = np.copy(self.faults["X"])
+            new_list.faults["Z"] = np.copy(self.faults["Z"])
+            x_faults, z_faults = new_list.faults["X"], new_list.faults["Z"]
+            ret = new_list
+
+        z_faults[:, control1] ^= x_faults[:, control2] & x_faults[:, control3]
+        z_faults[:, control2] ^= x_faults[:, control1] & x_faults[:, control3]
+        z_faults[:, control3] ^= x_faults[:, control1] & x_faults[:, control2]
+
+        return ret
+    
+    def apply_ccx(self, control1: int, control2: int, target: int, inplace: bool = True) -> XZFaultList:
+        """Apply a CCX (Toffoli) gate to the faults in the list, by applying a H_target x CCZ x H_target
+
+        Args:
+            control1: The first control qubit.
+            control2: The second control qubit.
+            target: The target qubit.
+            inplace: If True, modifies the current fault list. If False, returns a new XZFaultList.
+
+        Returns:
+            A new XZFaultList with updated faults if inplace is False, otherwise self.
+
+        Raises:
+            ValueError: If any qubit index is out of range.
+            ValueError: If qubits are not distinct.
+        """
+        self.ensure_apply_valid_input(control1, control2, target)
+
+        _fault_list = self.apply_hadamard(target, inplace = inplace)
+        _fault_list.apply_ccz(control1, control2, target)
+        _fault_list.apply_hadamard(target)
+
+        return _fault_list
+    
+    def ensure_apply_valid_input(self, *qubits: int) -> bool:
+        """Ensures that the input into apply_* functions are valid.
+
+        Raises:
+            ValueError: If any qubit index is out of range.
+            ValueError: If qubits are not distinct.
+
+        Returns:
+            bool: True if everything is okay
+        """
+        _n_q = len(qubits)
+        if any(not 0 <= _q < self.num_qubits for _q in qubits):
+            msg = f"Qubit {'indices' if _n_q > 1 else 'index'} must be between 0 and {self.num_qubits - 1}."
+            raise ValueError(msg)
+        if _n_q > 1 and len(set(qubits)) != _n_q:
+            msg = "All qubits must be different."
+            raise ValueError(msg)
+        
+        return True
+
+    def reduce_to_coset_leaders(self, generators: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None], inplace: bool = True) -> XZFaultList:
+        """Reduce fault list to coset leaders using provided generators.
+
+        Applies coset leader reduction to X and Z type faults independently using the 
+        corresponding generators. This is useful for reducing error syndromes to their 
+        canonical representatives in quantum error correction.
+
+        Args:
+            generators (Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]): 
+                Tuple of (x_generators, z_generators). Each should be a 2D numpy array with 
+                shape (num_generators, num_qubits) or None to skip reduction for that error type.
+            inplace (bool, optional): If True, modify this fault list in place. 
+                If False, return a copy with reductions applied. Defaults to True.
+
+        Raises:
+            ValueError: If any generator array has incorrect dimensions (must be 2D with num_qubits columns).
+            AssertionError: If generators tuple length is not 2.
+
+        Returns:
+            XZFaultList: The reduced fault list (self if inplace=True, otherwise a copy).
+        """
+        # Setting the corresponding generator to None means no reduction is done
+        
+        assert len(generators) == 2, "Generators should be a tuple of x_generators and z_generators"
+
+        # use qecc_faults.coset_leader(single_fault, generators) for x and z
+        ret = self if inplace else self.copy()
+
+        for error_type, _g in zip(ret.faults, generators):
+            # Ensure generators are numpy arrays (may be empty)
+            _g = None if _g is None else np.asarray(_g, dtype=np.int8)
+
+            # Check sizes
+            if _g is not None and (_g.ndim != 2 or _g.shape[1] != self.num_qubits):
+                msg = f"Generators must be a 2D array with {self.num_qubits} columns."
+                raise ValueError(msg)
+            
+            if ret.faults[error_type].shape[0] > 0 and _g is not None and _g.size > 0:
+                for i in range(ret.faults[error_type].shape[0]):
+                    ret.faults[error_type][i] = np.asarray(coset_leader(ret.faults[error_type][i], _g), dtype=np.int8)
+
+        return ret
+
+    def __repr__(self) -> str:
+        _repr = [
+            object.__repr__(self),
+            "X:",
+            repr(self.faults["X"]),
+            "Z:",
+            repr(self.faults["Z"])
+        ]
+        return "\n".join(_repr)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -835,5 +835,11 @@ class XZFaultList:
 
     def __repr__(self) -> str:
         """Return a string representation of the XZFaultList."""
-        repr_ = [object.__repr__(self) + f" num_qubits: {self.num_qubits}", "X:", repr(self.faults["X"]), "Z:", repr(self.faults["Z"])]
+        repr_ = [
+            object.__repr__(self) + f" num_qubits: {self.num_qubits}",
+            "X:",
+            repr(self.faults["X"]),
+            "Z:",
+            repr(self.faults["Z"]),
+        ]
         return "\n".join(repr_)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -581,7 +581,7 @@ class XZFaultList:
         new_list.faults["Z"] = np.copy(self.faults["Z"])
         return new_list
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[npt.NDArray[np.int8], npt.NDArray[np.int8]]]:
         """Iterate over fault pairs in the list.
 
         Yields:

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -543,6 +543,7 @@ class XZFaultList:
             faults: A tuple of (x_faults, z_faults) where each is a 2D numpy array.
                 Each array should have num_qubits columns.
                 One of the faults may be set to None, which is treated as an all-zero fault.
+                x_faults and z_faults should also have the same number of rows as they are coupled
 
         Raises:
             ValueError: If fault arrays don't have the correct shape.
@@ -563,8 +564,14 @@ class XZFaultList:
             x_faults = np.asarray(x_faults, dtype=np.int8)
             z_faults = np.asarray(z_faults, dtype=np.int8)
 
+        if x_faults.ndim != 2 or z_faults.ndim != 2:
+            msg = "Fault arrays must be 2-dimensional."
+            raise ValueError(msg)
         if x_faults.shape[1] != self.num_qubits or z_faults.shape[1] != self.num_qubits:
             msg = f"Faults must have {self.num_qubits} columns."
+            raise ValueError(msg)
+        if x_faults.shape[0] != z_faults.shape[0]:
+            msg = "Fault arrays must have the same number of rows."
             raise ValueError(msg)
 
         self.faults["X"] = np.vstack([self.faults["X"], x_faults])

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -771,12 +771,12 @@ class XZFaultList:
     def ensure_apply_valid_input(self, *qubits: int) -> bool:
         """Ensures that the input into apply_* functions are valid.
 
+        Returns:
+            bool: True if everything is okay
+
         Raises:
             ValueError: If any qubit index is out of range.
             ValueError: If qubits are not distinct.
-
-        Returns:
-            bool: True if everything is okay
         """
         n_q = len(qubits)
         if any(not 0 <= q < self.num_qubits for q in qubits):
@@ -804,12 +804,12 @@ class XZFaultList:
             inplace (bool, optional): If True, modify this fault list in place.
                 If False, return a copy with reductions applied. Defaults to True.
 
+        Returns:
+            XZFaultList: The reduced fault list (self if inplace=True, otherwise a copy).
+
         Raises:
             ValueError: If any generator array has incorrect dimensions (must be 2D with num_qubits columns).
             AssertionError: If generators tuple length is not 2.
-
-        Returns:
-            XZFaultList: The reduced fault list (self if inplace=True, otherwise a copy).
         """
         # Setting the corresponding generator to None means no reduction is done
 

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -818,9 +818,9 @@ class XZFaultList:
         # use qecc_faults.coset_leader(single_fault, generators) for x and z
         ret = self if inplace else self.copy()
 
-        for error_type, _g in zip(ret.faults, generators, strict=False):
+        for error_type, g_ in zip(ret.faults, generators, strict=False):
             # Ensure generators are numpy arrays (may be empty)
-            g = None if _g is None else np.asarray(_g, dtype=np.int8)
+            g = None if g_ is None else np.asarray(g_, dtype=np.int8)
 
             # Check sizes
             if g is not None and (g.ndim != 2 or g.shape[1] != self.num_qubits):

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 import z3
@@ -485,9 +485,9 @@ def t_distinct(fs1: PureFaultSet, fs2: PureFaultSet, t: int, stabs: npt.NDArray[
     return True
 
 
-class XZFaultList():
+class XZFaultList:
     def __init__(self, num_qubits: int) -> None:
-        """Initialise a XZFaultList object
+        """Initialise a XZFaultList object.
 
         Args:
             num_qubits (int): The number of qubits in the circuit
@@ -498,12 +498,12 @@ class XZFaultList():
             "Z": np.zeros((0, num_qubits), dtype=np.int8),
         }
 
-    def add_fault(self, faults: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
+    def add_fault(self, faults: tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
         """Add a single fault pair (X error, Z error) to the fault list.
 
         Args:
             faults: A tuple of (x_fault, z_fault) where each is a 1D numpy array.
-                Each array must have length num_qubits. 
+                Each array must have length num_qubits.
                 One of the faults may be set to None, which is treated as an all-zero fault.
 
         Raises:
@@ -514,7 +514,8 @@ class XZFaultList():
 
         x_fault, z_fault = faults
         if x_fault is None and z_fault is None:
-            raise ValueError("At least one fault must be provided.")
+            msg = "At least one fault must be provided."
+            raise ValueError(msg)
 
         if x_fault is None:
             z_fault = np.asarray(z_fault, dtype=np.int8)
@@ -533,7 +534,7 @@ class XZFaultList():
         self.faults["X"] = np.vstack([self.faults["X"], x_fault])
         self.faults["Z"] = np.vstack([self.faults["Z"], z_fault])
 
-    def add_faults(self, faults: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
+    def add_faults(self, faults: tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]) -> None:
         """Add multiple fault pairs to the fault list.
 
         Args:
@@ -547,7 +548,8 @@ class XZFaultList():
         """
         x_faults, z_faults = faults
         if x_faults is None and z_faults is None:
-            raise ValueError("At least one fault array must be provided.")
+            msg = "At least one fault array must be provided."
+            raise ValueError(msg)
 
         if x_faults is None:
             z_faults = np.asarray(z_faults, dtype=np.int8)
@@ -619,7 +621,7 @@ class XZFaultList():
             ret = new_list
 
         # Apply CNOT
-        x_faults[:, target]  ^= x_faults[:, control]
+        x_faults[:, target] ^= x_faults[:, control]
         z_faults[:, control] ^= z_faults[:, target]
 
         return ret
@@ -661,7 +663,7 @@ class XZFaultList():
         )
 
         return new_list
-        
+
     def apply_reset(self, qubit: int, inplace: bool = True) -> XZFaultList:
         """Apply a reset operation to the faults in the list.
 
@@ -690,12 +692,12 @@ class XZFaultList():
         new_list.faults["X"][:, qubit] = 0
         new_list.faults["Z"][:, qubit] = 0
         return new_list
-        
+
     def apply_ccz(self, control1: int, control2: int, control3: int, inplace: bool = True) -> XZFaultList:
         """Apply a CCZ gate to the faults in the list.
 
         The propagation model is adversarial: any pair of X faults on two controls
-        will induce a Z fault on the third control. 
+        will induce a Z fault on the third control.
         We can do this also because the given circuit is assumed to be fault tolerant.
 
         Note: CCZ is symmetrical, thus there is no "target" per se
@@ -718,7 +720,7 @@ class XZFaultList():
 
         # By right, the state of the qubits matter, which is why you can't simply propagate pauli gates through a CCZ gate.
 
-        # Adverserial Fault Propagation for CCZ:
+        # Adversarial Fault Propagation for CCZ:
         # We do a simple logic, that every pair of X faults leads, in the worst case, to a Z fault on the other control. So we can just add all pairs of X faults as Z faults.
         # Z_i ^= (X_j & X_k) for all distinct i, j, k in {control1, control2, control3}
 
@@ -739,9 +741,9 @@ class XZFaultList():
         z_faults[:, control3] ^= x_faults[:, control1] & x_faults[:, control2]
 
         return ret
-    
+
     def apply_ccx(self, control1: int, control2: int, target: int, inplace: bool = True) -> XZFaultList:
-        """Apply a CCX (Toffoli) gate to the faults in the list, by applying a H_target x CCZ x H_target
+        """Apply a CCX (Toffoli) gate to the faults in the list, by applying a H_target x CCZ x H_target.
 
         Args:
             control1: The first control qubit.
@@ -758,12 +760,12 @@ class XZFaultList():
         """
         self.ensure_apply_valid_input(control1, control2, target)
 
-        _fault_list = self.apply_hadamard(target, inplace = inplace)
-        _fault_list.apply_ccz(control1, control2, target)
-        _fault_list.apply_hadamard(target)
+        fault_list = self.apply_hadamard(target, inplace=inplace)
+        fault_list.apply_ccz(control1, control2, target)
+        fault_list.apply_hadamard(target)
 
-        return _fault_list
-    
+        return fault_list
+
     def ensure_apply_valid_input(self, *qubits: int) -> bool:
         """Ensures that the input into apply_* functions are valid.
 
@@ -774,28 +776,30 @@ class XZFaultList():
         Returns:
             bool: True if everything is okay
         """
-        _n_q = len(qubits)
-        if any(not 0 <= _q < self.num_qubits for _q in qubits):
-            msg = f"Qubit {'indices' if _n_q > 1 else 'index'} must be between 0 and {self.num_qubits - 1}."
+        n_q = len(qubits)
+        if any(not 0 <= q < self.num_qubits for q in qubits):
+            msg = f"Qubit {'indices' if n_q > 1 else 'index'} must be between 0 and {self.num_qubits - 1}."
             raise ValueError(msg)
-        if _n_q > 1 and len(set(qubits)) != _n_q:
+        if n_q > 1 and len(set(qubits)) != n_q:
             msg = "All qubits must be different."
             raise ValueError(msg)
-        
+
         return True
 
-    def reduce_to_coset_leaders(self, generators: Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None], inplace: bool = True) -> XZFaultList:
+    def reduce_to_coset_leaders(
+        self, generators: tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None], inplace: bool = True
+    ) -> XZFaultList:
         """Reduce fault list to coset leaders using provided generators.
 
-        Applies coset leader reduction to X and Z type faults independently using the 
-        corresponding generators. This is useful for reducing error syndromes to their 
+        Applies coset leader reduction to X and Z type faults independently using the
+        corresponding generators. This is useful for reducing error syndromes to their
         canonical representatives in quantum error correction.
 
         Args:
-            generators (Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]): 
-                Tuple of (x_generators, z_generators). Each should be a 2D numpy array with 
+            generators (Tuple[npt.NDArray[np.int8] | None, npt.NDArray[np.int8] | None]):
+                Tuple of (x_generators, z_generators). Each should be a 2D numpy array with
                 shape (num_generators, num_qubits) or None to skip reduction for that error type.
-            inplace (bool, optional): If True, modify this fault list in place. 
+            inplace (bool, optional): If True, modify this fault list in place.
                 If False, return a copy with reductions applied. Defaults to True.
 
         Raises:
@@ -806,33 +810,27 @@ class XZFaultList():
             XZFaultList: The reduced fault list (self if inplace=True, otherwise a copy).
         """
         # Setting the corresponding generator to None means no reduction is done
-        
+
         assert len(generators) == 2, "Generators should be a tuple of x_generators and z_generators"
 
         # use qecc_faults.coset_leader(single_fault, generators) for x and z
         ret = self if inplace else self.copy()
 
-        for error_type, _g in zip(ret.faults, generators):
+        for error_type, g in zip(ret.faults, generators, strict=False):
             # Ensure generators are numpy arrays (may be empty)
-            _g = None if _g is None else np.asarray(_g, dtype=np.int8)
+            g = None if g is None else np.asarray(g, dtype=np.int8)
 
             # Check sizes
-            if _g is not None and (_g.ndim != 2 or _g.shape[1] != self.num_qubits):
+            if g is not None and (g.ndim != 2 or g.shape[1] != self.num_qubits):
                 msg = f"Generators must be a 2D array with {self.num_qubits} columns."
                 raise ValueError(msg)
-            
-            if ret.faults[error_type].shape[0] > 0 and _g is not None and _g.size > 0:
+
+            if ret.faults[error_type].shape[0] > 0 and g is not None and g.size > 0:
                 for i in range(ret.faults[error_type].shape[0]):
-                    ret.faults[error_type][i] = np.asarray(coset_leader(ret.faults[error_type][i], _g), dtype=np.int8)
+                    ret.faults[error_type][i] = np.asarray(coset_leader(ret.faults[error_type][i], g), dtype=np.int8)
 
         return ret
 
     def __repr__(self) -> str:
-        _repr = [
-            object.__repr__(self),
-            "X:",
-            repr(self.faults["X"]),
-            "Z:",
-            repr(self.faults["Z"])
-        ]
-        return "\n".join(_repr)
+        repr_ = [object.__repr__(self), "X:", repr(self.faults["X"]), "Z:", repr(self.faults["Z"])]
+        return "\n".join(repr_)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,6 +18,8 @@ import z3
 from mqt.qecc.mod2 import row_echelon
 
 from .synthesis_utils import symbolic_vector_add, symbolic_vector_eq, vars_to_stab
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable, Iterator
@@ -815,23 +818,31 @@ class XZFaultList:
         Raises:
             ValueError: If any generator array has incorrect dimensions (must be 2D with num_qubits columns).
             AssertionError: If generators tuple length is not 2.
+
+        Warning:
+            This calls :func:`coset_leader` once per fault row, so it might take a while.
         """
         # Setting the corresponding generator to None means no reduction is done
 
         assert len(generators) == 2, "Generators should be a tuple of x_generators and z_generators"
 
-        # use qecc_faults.coset_leader(single_fault, generators) for x and z
-        ret = self if inplace else self.copy()
+        logger.warning("This calls coset_leader once per fault row, so it might take a while.")
 
-        for error_type, g_ in zip(ret.faults, generators, strict=False):
-            # Ensure generators are numpy arrays (may be empty)
-            g = None if g_ is None else np.asarray(g_, dtype=np.int8)
+        # Normalize and validate both generator arrays before mutating any faults.
+        generator_map: dict[str, npt.NDArray[np.int8] | None] = {
+            "X": None if generators[0] is None else np.asarray(generators[0], dtype=np.int8),
+            "Z": None if generators[1] is None else np.asarray(generators[1], dtype=np.int8),
+        }
 
-            # Check sizes
+        for g in generator_map.values():
             if g is not None and (g.ndim != 2 or g.shape[1] != self.num_qubits):
                 msg = f"Generators must be a 2D array with {self.num_qubits} columns."
                 raise ValueError(msg)
 
+        ret = self if inplace else self.copy()
+
+        for error_type in ("X", "Z"):
+            g = generator_map[error_type]
             if ret.faults[error_type].shape[0] > 0 and g is not None and g.size > 0:
                 for i in range(ret.faults[error_type].shape[0]):
                     ret.faults[error_type][i] = np.asarray(coset_leader(ret.faults[error_type][i], g), dtype=np.int8)

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -486,6 +486,8 @@ def t_distinct(fs1: PureFaultSet, fs2: PureFaultSet, t: int, stabs: npt.NDArray[
 
 
 class XZFaultList:
+    """Represents an ordered list of coupled pure faults (X-type and Z-type) in a quantum circuit."""
+
     def __init__(self, num_qubits: int) -> None:
         """Initialise a XZFaultList object.
 

--- a/src/mqt/qecc/circuit_synthesis/faults.py
+++ b/src/mqt/qecc/circuit_synthesis/faults.py
@@ -757,6 +757,10 @@ class XZFaultList:
     def apply_ccx(self, control1: int, control2: int, target: int, inplace: bool = True) -> XZFaultList:
         """Apply a CCX (Toffoli) gate to the faults in the list, by applying a H_target x CCZ x H_target.
 
+        NOTE: Check `test_faults.py` for interesting cases (e.g. should a Z on target spread to control1 and control2?)
+        NOTE: Perhaps a good idea to generate a propagation truth table.
+        NOTE: Currently just a first approximation.
+
         Args:
             control1: The first control qubit.
             control2: The second control qubit.

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -806,6 +806,9 @@ def test_apply_cnot_rejects_invalid_qubits(fault_list: XZFaultList) -> None:
     with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
         fault_list.apply_cnot(control=3, target=1)
 
+    with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+        fault_list.apply_cnot(control=-1, target=1)
+
 
 def test_apply_hadamard_swaps_x_and_z_on_target_qubit(fault_list: XZFaultList) -> None:
     """Hadamard on a qubit swaps X and Z faults on that qubit position."""

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -721,6 +721,28 @@ def test_add_faults_rejects_wrong_column_count() -> None:
         ))
 
 
+def test_add_faults_rejects_mismatched_row_counts() -> None:
+    """Adding coupled fault arrays with different row counts raises a ValueError."""
+    faults = XZFaultList(num_qubits=3)
+
+    with pytest.raises(ValueError, match=r"Fault arrays must have the same number of rows."):
+        faults.add_faults((
+            np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8),
+            np.array([[0, 1, 0]], dtype=np.int8),
+        ))
+
+
+def test_add_faults_rejects_1d_inputs() -> None:
+    """Adding 1D fault arrays raises a ValueError before shape-based access."""
+    faults = XZFaultList(num_qubits=3)
+
+    with pytest.raises(ValueError, match=r"Fault arrays must be 2-dimensional."):
+        faults.add_faults((
+            np.array([1, 0, 0], dtype=np.int8),
+            np.array([[0, 1, 0]], dtype=np.int8),
+        ))
+
+
 def test_add_faults_replaces_none_with_zeros() -> None:
     """None arrays passed to add_faults are replaced by zero arrays of proper shape."""
     faults = XZFaultList(num_qubits=3)

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -1097,9 +1097,9 @@ def test_reduce_to_coset_leaders_both_generators() -> None:
     # Both matching faults should be reduced to zero
     assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
     assert np.array_equal(reduced.faults["Z"][0], np.array([0, 0, 0], dtype=np.int8))
-    # Non-matching faults should be reduced to their coset leaders
-    assert reduced.faults["X"].shape[0] == 2
-    assert reduced.faults["Z"].shape[0] == 2
+    # Non-matching faults are already their own coset leaders
+    assert np.array_equal(reduced.faults["X"][1], np.array([0, 1, 0], dtype=np.int8))
+    assert np.array_equal(reduced.faults["Z"][1], np.array([1, 0, 0], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_inplace() -> None:
@@ -1167,6 +1167,8 @@ def test_reduce_to_coset_leaders_multiple_faults() -> None:
     # First two faults are in the stabilizer group, third should be reduced to coset leader
     assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
     assert np.array_equal(reduced.faults["X"][1], np.array([0, 0, 0], dtype=np.int8))
+    # The third fault equals the product of both generators, so it also reduces to zero
+    assert np.array_equal(reduced.faults["X"][2], np.array([0, 0, 0], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_invalid_generator_shape() -> None:

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -924,6 +924,7 @@ def test_apply_ccz_unit_tests() -> None:
         assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
         assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
 
+
 def test_apply_ccx_unit_tests() -> None:
     """Unit tests: verify CCX (Toffoli) X-output mapping for control/target combinations."""
     # controls are always qubits 0 and 1, target is qubit 2
@@ -1170,4 +1171,3 @@ def test_xzfaultlist_repr_empty() -> None:
     # Check that the representation contains relevant information
     assert "XZFaultList" in repr_str
     assert "num_qubits: 2" in repr_str
-

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -1108,12 +1108,6 @@ def test_reduce_to_coset_leaders_empty_generators() -> None:
 
     reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
-<<<<<<< HEAD
-	# Faults should remain unchanged
-	assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
-	assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
-=======
     # Faults should remain unchanged
     assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
     assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
->>>>>>> d0b4bc68 (🎨 pre-commit fixes)

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pytest
 
@@ -1011,6 +1013,19 @@ def test_reduce_to_coset_leaders_no_generators() -> None:
     assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
 
 
+def test_reduce_to_coset_leaders_logs_runtime_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Coset leader reduction warns that it iterates once per fault row."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+
+    with caplog.at_level(logging.WARNING):
+        faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+    assert "This calls coset_leader once per fault row, so it might take a while." in caplog.text
+
+
 def test_reduce_to_coset_leaders_x_generators() -> None:
     """Coset leader reduction applies X generators to reduce X faults to leaders."""
     faults = XZFaultList(num_qubits=3)
@@ -1080,6 +1095,23 @@ def test_reduce_to_coset_leaders_inplace() -> None:
     assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
     # Z fault should remain unchanged
     assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_inplace_invalid_generators_preserves_state() -> None:
+    """Validation failures must not partially mutate an inplace fault list."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    z_generators = np.array([[1, 0]], dtype=np.int8)
+    original_x = faults.faults["X"].copy()
+    original_z = faults.faults["Z"].copy()
+
+    with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
+        faults.reduce_to_coset_leaders((x_generators, z_generators), inplace=True)
+
+    assert np.array_equal(faults.faults["X"], original_x)
+    assert np.array_equal(faults.faults["Z"], original_z)
 
 
 def test_reduce_to_coset_leaders_not_inplace() -> None:

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from mqt.qecc.circuit_synthesis.circuits import CNOTCircuit
-from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader, stabilizer_equivalent, t_distinct
+from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader, stabilizer_equivalent, t_distinct, XZFaultList
 
 
 @pytest.fixture
@@ -637,3 +637,446 @@ def test_permute_qubits_inplace():
     fault_set.permute_qubits(permutation, inplace=True)
 
     assert fault_set != PureFaultSet.from_fault_array(faults), "Faults were not permuted correctly in place"
+
+"""XZFaultList Tests"""
+@pytest.fixture
+def fault_list() -> XZFaultList:
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 1], dtype=np.int8)))
+	return faults
+
+
+def test_initialization_creates_empty_fault_arrays() -> None:
+	faults = XZFaultList(num_qubits=4)
+
+	assert faults.num_qubits == 4
+	assert np.array_equal(faults.faults["X"], np.zeros((0, 4), dtype=np.int8))
+	assert np.array_equal(faults.faults["Z"], np.zeros((0, 4), dtype=np.int8))
+
+
+def test_add_fault_appends_x_and_z_rows() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	assert np.array_equal(faults.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+
+
+def test_add_fault_rejects_wrong_length() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"Faults must have length 3."):
+		faults.add_fault((np.array([1, 0], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+
+def test_add_fault_replaces_none_with_zeros() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	faults.add_fault((None, np.array([0, 1, 0], dtype=np.int8)))
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), None))
+
+	assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8))
+	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [0, 0, 0]], dtype=np.int8))
+
+
+def test_add_fault_rejects_both_none() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"At least one fault must be provided."):
+		faults.add_fault((None, None))
+
+
+def test_add_faults_appends_multiple_rows() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	faults.add_faults(
+		(
+			np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8),
+			np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
+		)
+	)
+
+	assert np.array_equal(faults.faults["X"], np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8))
+	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
+
+def test_add_faults_rejects_wrong_column_count() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"Faults must have 3 columns."):
+		faults.add_faults(
+			(
+				np.array([[1, 0]], dtype=np.int8),
+				np.array([[0, 1]], dtype=np.int8),
+			)
+		)
+
+
+def test_add_faults_replaces_none_with_zeros() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	faults.add_faults(
+		(
+			None,
+			np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
+		)
+	)
+	faults.add_faults(
+		(
+			np.array([[1, 0, 1]], dtype=np.int8),
+			None,
+		)
+	)
+
+	assert np.array_equal(
+		faults.faults["X"],
+		np.array([[0, 0, 0], [0, 0, 0], [1, 0, 1]], dtype=np.int8),
+	)
+	assert np.array_equal(
+		faults.faults["Z"],
+		np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0]], dtype=np.int8),
+	)
+
+
+def test_add_faults_rejects_both_none() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"At least one fault array must be provided."):
+		faults.add_faults((None, None))
+
+
+def test_copy_returns_independent_fault_list(fault_list: XZFaultList) -> None:
+	copied = fault_list.copy()
+
+	copied.faults["X"][0, 0] = 0
+	copied.faults["Z"][1, 2] = 0
+
+	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
+
+def test_iter_yields_fault_pairs_in_order(fault_list: XZFaultList) -> None:
+	pairs = list(fault_list)
+
+	assert len(pairs) == 2
+	assert np.array_equal(pairs[0][0], np.array([1, 0, 1], dtype=np.int8))
+	assert np.array_equal(pairs[0][1], np.array([0, 1, 0], dtype=np.int8))
+	assert np.array_equal(pairs[1][0], np.array([0, 1, 0], dtype=np.int8))
+	assert np.array_equal(pairs[1][1], np.array([1, 0, 1], dtype=np.int8))
+
+
+def test_apply_cnot_updates_x_and_z_faults(fault_list: XZFaultList) -> None:
+	updated = fault_list.apply_cnot(control=0, target=1, inplace=False)
+
+	expected_x = np.array([[1, 1, 1], [0, 1, 0]], dtype=np.int8)
+	expected_z = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.int8)
+
+	assert np.array_equal(updated.faults["X"], expected_x)
+	assert np.array_equal(updated.faults["Z"], expected_z)
+	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
+
+def test_apply_cnot_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
+	result = fault_list.apply_cnot(control=1, target=2, inplace=True)
+
+	expected_x = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
+	expected_z = np.array([[0, 1, 0], [1, 1, 1]], dtype=np.int8)
+
+	assert result is fault_list
+	assert np.array_equal(fault_list.faults["X"], expected_x)
+	assert np.array_equal(fault_list.faults["Z"], expected_z)
+
+
+def test_apply_cnot_rejects_invalid_qubits(fault_list: XZFaultList) -> None:
+	with pytest.raises(ValueError, match=r"All qubits must be different."):
+		fault_list.apply_cnot(control=1, target=1)
+
+	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+		fault_list.apply_cnot(control=3, target=1)
+
+
+def test_apply_hadamard_swaps_x_and_z_on_target_qubit(fault_list: XZFaultList) -> None:
+	updated = fault_list.apply_hadamard(qubit=1, inplace=False)
+
+	expected_x = np.array([[1, 1, 1], [0, 0, 0]], dtype=np.int8)
+	expected_z = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.int8)
+
+	assert np.array_equal(updated.faults["X"], expected_x)
+	assert np.array_equal(updated.faults["Z"], expected_z)
+	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
+
+def test_apply_hadamard_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
+	result = fault_list.apply_hadamard(qubit=0, inplace=True)
+
+	expected_x = np.array([[0, 0, 1], [1, 1, 0]], dtype=np.int8)
+	expected_z = np.array([[1, 1, 0], [0, 0, 1]], dtype=np.int8)
+
+	assert result is fault_list
+	assert np.array_equal(fault_list.faults["X"], expected_x)
+	assert np.array_equal(fault_list.faults["Z"], expected_z)
+
+
+def test_apply_hadamard_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
+	with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
+		fault_list.apply_hadamard(qubit=3)
+
+
+def test_apply_reset_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
+	with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
+		fault_list.apply_reset(qubit=3)
+
+
+def test_apply_ccz_updates_z_faults_non_inplace() -> None:
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+	updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
+
+	expected_x = np.array([[1, 1, 1]], dtype=np.int8)
+	expected_z = np.array([[1, 1, 1]], dtype=np.int8)
+
+	assert np.array_equal(updated.faults["X"], expected_x)
+	assert np.array_equal(updated.faults["Z"], expected_z)
+	assert np.array_equal(faults.faults["X"], np.array([[1, 1, 1]], dtype=np.int8))
+	assert np.array_equal(faults.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+
+
+def test_apply_ccz_inplace_modifies_current_fault_list() -> None:
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+	result = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=True)
+
+	expected_x = np.array([[1, 1, 1]], dtype=np.int8)
+	expected_z = np.array([[1, 1, 1]], dtype=np.int8)
+
+	assert result is faults
+	assert np.array_equal(faults.faults["X"], expected_x)
+	assert np.array_equal(faults.faults["Z"], expected_z)
+
+
+def test_apply_ccz_rejects_invalid_controls() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"All qubits must be different."):
+		faults.apply_ccz(control1=0, control2=0, control3=2)
+
+	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+		faults.apply_ccz(control1=0, control2=1, control3=3)
+
+def test_apply_ccx_rejects_invalid_qubits() -> None:
+	faults = XZFaultList(num_qubits=3)
+
+	with pytest.raises(ValueError, match=r"All qubits must be different."):
+		faults.apply_ccx(control1=0, control2=1, target=1)
+
+	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+		faults.apply_ccx(control1=0, control2=1, target=3)
+
+def test_apply_ccz_unit_tests() -> None:
+	# its always 0,1,2 for the controls
+	# input x, output x, output z
+	unit_tests = [
+		[(0, 0, 0), (0, 0, 0), (0, 0, 0)],
+		[(0, 0, 1), (0, 0, 1), (0, 0, 0)],
+		[(0, 1, 0), (0, 1, 0), (0, 0, 0)],
+		[(0, 1, 1), (0, 1, 1), (1, 0, 0)],
+		[(1, 0, 0), (1, 0, 0), (0, 0, 0)],
+		[(1, 0, 1), (1, 0, 1), (0, 1, 0)],
+		[(1, 1, 0), (1, 1, 0), (0, 0, 1)],
+		[(1, 1, 1), (1, 1, 1), (1, 1, 1)],
+	]
+	
+	for input_x, expected_x, expected_z in unit_tests:
+		faults = XZFaultList(num_qubits=3)
+		faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+		updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
+
+		assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
+		assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
+
+
+def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> None:
+	updated = fault_list.apply_reset(qubit=1, inplace=False)
+
+	expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
+	expected_z = np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8)
+
+	assert np.array_equal(updated.faults["X"], expected_x)
+	assert np.array_equal(updated.faults["Z"], expected_z)
+	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
+# based on tests for mqt.qecc.circuit_synthesis.faults.coset_leader
+def test_reduce_to_coset_leaders_no_generators() -> None:
+	"""Test coset leader reduction with no generators (should not modify faults)."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	# No generators - faults should remain unchanged
+	reduced = faults.reduce_to_coset_leaders((None, None), inplace=False)
+
+	assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+	assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_x_generators() -> None:
+	"""Test coset leader reduction with X generators."""
+	faults = XZFaultList(num_qubits=3)
+	# Add X fault that is in the stabilizer group
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+	# X generator that matches the X fault
+	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+	# X fault should be reduced to zero (it's in the stabilizer group)
+	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+	# Z fault should remain unchanged
+	assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_z_generators() -> None:
+	"""Test coset leader reduction with Z generators."""
+	faults = XZFaultList(num_qubits=3)
+	# Add Z fault that is in the stabilizer group
+	faults.add_fault((np.array([0, 0, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
+
+	# Z generator that matches the Z fault
+	z_generators = np.array([[0, 1, 1]], dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((None, z_generators), inplace=False)
+
+	# X fault should remain unchanged
+	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+	# Z fault should be reduced to zero
+	assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_both_generators() -> None:
+	"""Test coset leader reduction with both X and Z generators."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
+	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 0], dtype=np.int8)))
+
+	# Generators that match the faults
+	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+	z_generators = np.array([[0, 1, 1]], dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((x_generators, z_generators), inplace=False)
+
+	# Both matching faults should be reduced to zero
+	assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
+	assert np.array_equal(reduced.faults["Z"][0], np.array([0, 0, 0], dtype=np.int8))
+	# Non-matching faults should be reduced to their coset leaders
+	assert reduced.faults["X"].shape[0] == 2
+	assert reduced.faults["Z"].shape[0] == 2
+
+
+def test_reduce_to_coset_leaders_inplace() -> None:
+	"""Test that inplace=True modifies the original fault list."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+
+	result = faults.reduce_to_coset_leaders((x_generators, None), inplace=True)
+
+	# Result should be the same object
+	assert result is faults
+	# X fault should be reduced
+	assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+	# Z fault should remain unchanged
+	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_not_inplace() -> None:
+	"""Test that inplace=False returns a new independent fault list."""
+	original = XZFaultList(num_qubits=3)
+	original.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+	reduced = original.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+	# Result should be a different object
+	assert reduced is not original
+	# Reduced fault list should be modified
+	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+	# Original should remain unchanged
+	assert np.array_equal(original.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_multiple_faults() -> None:
+	"""Test coset leader reduction with multiple faults."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+	# Two X generators
+	x_generators = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+	# First two faults are in the stabilizer group, third should be reduced to coset leader
+	assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
+	assert np.array_equal(reduced.faults["X"][1], np.array([0, 0, 0], dtype=np.int8))
+
+
+def test_reduce_to_coset_leaders_invalid_generator_shape() -> None:
+	"""Test that invalid generator shapes raise ValueError."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	# Wrong number of columns in generator
+	x_generators = np.array([[1, 0]], dtype=np.int8)
+
+	with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
+		faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+
+def test_reduce_to_coset_leaders_invalid_generator_dimension() -> None:
+	"""Test that 1D generators raise ValueError."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	# 1D array instead of 2D
+	x_generators = np.array([1, 0, 1], dtype=np.int8)
+
+	with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
+		faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+
+def test_reduce_to_coset_leaders_empty_fault_list() -> None:
+	"""Test coset leader reduction with an empty fault list."""
+	faults = XZFaultList(num_qubits=3)
+	
+	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+	# Should remain empty
+	assert reduced.faults["X"].shape == (0, 3)
+	assert reduced.faults["Z"].shape == (0, 3)
+
+
+def test_reduce_to_coset_leaders_empty_generators() -> None:
+	"""Test coset leader reduction with empty generators (no reduction applied)."""
+	faults = XZFaultList(num_qubits=3)
+	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+	# Empty generators
+	x_generators = np.empty((0, 3), dtype=np.int8)
+
+	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+	# Faults should remain unchanged
+	assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+	assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -928,21 +928,21 @@ def test_apply_ccx_rejects_invalid_qubits() -> None:
 def test_apply_ccz_unit_tests() -> None:
     """Unit tests: verify CCZ truth table mapping from input X to output X and Z."""
     # its always 0,1,2 for the controls
-    # input x, output x, output z
+    # input x, input z, output x, output z
     unit_tests = [
-        [(0, 0, 0), (0, 0, 0), (0, 0, 0)],
-        [(0, 0, 1), (0, 0, 1), (0, 0, 0)],
-        [(0, 1, 0), (0, 1, 0), (0, 0, 0)],
-        [(0, 1, 1), (0, 1, 1), (1, 0, 0)],
-        [(1, 0, 0), (1, 0, 0), (0, 0, 0)],
-        [(1, 0, 1), (1, 0, 1), (0, 1, 0)],
-        [(1, 1, 0), (1, 1, 0), (0, 0, 1)],
-        [(1, 1, 1), (1, 1, 1), (1, 1, 1)],
+        [(0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)],
+        [(0, 0, 1), (0, 0, 0), (0, 0, 1), (0, 0, 0)],
+        [(0, 1, 0), (0, 0, 0), (0, 1, 0), (0, 0, 0)],
+        [(0, 1, 1), (1, 0, 0), (0, 1, 1), (0, 0, 0)], # NOTE: XOR with the existing 1,0,0 to give 0,0,0 (question is whether they should cancel)
+        [(1, 0, 0), (0, 0, 0), (1, 0, 0), (0, 0, 0)],
+        [(1, 0, 1), (0, 0, 0), (1, 0, 1), (0, 1, 0)],
+        [(1, 1, 1), (1, 0, 0), (1, 1, 1), (0, 1, 1)],
+        [(1, 1, 0), (0, 0, 0), (1, 1, 0), (0, 0, 1)],
     ]
 
-    for input_x, expected_x, expected_z in unit_tests:
+    for input_x, input_z, expected_x, expected_z in unit_tests:
         faults = XZFaultList(num_qubits=3)
-        faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+        faults.add_fault((np.array(input_x, dtype=np.int8), np.array(input_z, dtype=np.int8)))
 
         updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
 
@@ -967,12 +967,34 @@ def test_apply_ccx_unit_tests() -> None:
 
     for input_x, expected_x in unit_tests:
         faults = XZFaultList(num_qubits=3)
-        faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+        faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))  # isolate the X errors
 
         updated = faults.apply_ccx(control1=0, control2=1, target=2, inplace=False)
 
         assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
         assert np.array_equal(updated.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+
+def test_apply_ccx_unit_tests_inplace() -> None:
+    inplace_faults = XZFaultList(num_qubits=3)
+    inplace_faults.add_fault((np.array([1, 1, 0], dtype=np.int8), np.array([0, 0, 1], dtype=np.int8)))
+
+    result = inplace_faults.apply_ccx(control1=0, control2=1, target=2, inplace=True)
+
+    assert result is inplace_faults
+    assert np.array_equal(inplace_faults.faults["X"], np.array([[1, 1, 1]], dtype=np.int8))
+    assert np.array_equal(inplace_faults.faults["Z"], np.array([[1, 1, 1]], dtype=np.int8))
+
+    ## Explanation for the propagation:
+    # Input X-faults (1,1,0) → X1 and X2 are present:
+
+    # X1 → X1 + (X-spread to qubit 3)
+    # X2 → X2 + (X-spread to qubit 3)
+    # Union: qubits 1, 2, 3 all get X → output X-faults: (1,1,1)
+
+    # Input Z-faults (0,0,1) → Z3 is present:
+
+    # Z3 → Z3 + (Z-spread to qubits 1, 2)
+    # Union: qubits 1, 2, 3 all get Z → output Z-faults: (1,1,1)
 
 
 def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> None:

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -1138,3 +1138,33 @@ def test_reduce_to_coset_leaders_empty_generators() -> None:
     # Faults should remain unchanged
     assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
     assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+
+
+def test_xzfaultlist_repr() -> None:
+    """Test __repr__ of XZFaultList returns a string representation."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+
+    repr_str = repr(faults)
+
+    # Check that repr returns a string
+    assert isinstance(repr_str, str)
+    # Check that the representation contains relevant information
+    assert "XZFaultList" in repr_str
+    assert "num_qubits: 3" in repr_str
+    assert "[1, 0, 1]" in repr_str
+    assert "[0, 1, 0]" in repr_str
+
+
+def test_xzfaultlist_repr_empty() -> None:
+    """Test __repr__ of empty XZFaultList."""
+    faults = XZFaultList(num_qubits=2)
+
+    repr_str = repr(faults)
+
+    # Check that repr returns a string
+    assert isinstance(repr_str, str)
+    # Check that the representation contains relevant information
+    assert "XZFaultList" in repr_str
+    assert "num_qubits: 2" in repr_str
+

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -643,6 +643,7 @@ def test_permute_qubits_inplace():
 
 @pytest.fixture
 def fault_list() -> XZFaultList:
+    """Fixture to create a sample XZFaultList for testing."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
     faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 1], dtype=np.int8)))
@@ -650,6 +651,7 @@ def fault_list() -> XZFaultList:
 
 
 def test_initialization_creates_empty_fault_arrays() -> None:
+    """Verify initialization creates empty X and Z fault arrays for given qubit count."""
     faults = XZFaultList(num_qubits=4)
 
     assert faults.num_qubits == 4
@@ -658,6 +660,7 @@ def test_initialization_creates_empty_fault_arrays() -> None:
 
 
 def test_add_fault_appends_x_and_z_rows() -> None:
+    """Ensure adding a single XZ fault appends rows to X and Z arrays."""
     faults = XZFaultList(num_qubits=3)
 
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
@@ -667,6 +670,7 @@ def test_add_fault_appends_x_and_z_rows() -> None:
 
 
 def test_add_fault_rejects_wrong_length() -> None:
+    """Adding a fault with incorrect length raises a ValueError."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"Faults must have length 3."):
@@ -674,6 +678,7 @@ def test_add_fault_rejects_wrong_length() -> None:
 
 
 def test_add_fault_replaces_none_with_zeros() -> None:
+    """None X or Z entries are replaced by zero rows when adding a fault."""
     faults = XZFaultList(num_qubits=3)
 
     faults.add_fault((None, np.array([0, 1, 0], dtype=np.int8)))
@@ -684,6 +689,7 @@ def test_add_fault_replaces_none_with_zeros() -> None:
 
 
 def test_add_fault_rejects_both_none() -> None:
+    """Adding a fault with both X and Z equal to None raises a ValueError."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"At least one fault must be provided."):
@@ -691,6 +697,7 @@ def test_add_fault_rejects_both_none() -> None:
 
 
 def test_add_faults_appends_multiple_rows() -> None:
+    """Adding multiple faults appends corresponding rows to X and Z arrays."""
     faults = XZFaultList(num_qubits=3)
 
     faults.add_faults((
@@ -703,6 +710,7 @@ def test_add_faults_appends_multiple_rows() -> None:
 
 
 def test_add_faults_rejects_wrong_column_count() -> None:
+    """Adding fault arrays with incorrect column counts raises a ValueError."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"Faults must have 3 columns."):
@@ -713,6 +721,7 @@ def test_add_faults_rejects_wrong_column_count() -> None:
 
 
 def test_add_faults_replaces_none_with_zeros() -> None:
+    """None arrays passed to add_faults are replaced by zero arrays of proper shape."""
     faults = XZFaultList(num_qubits=3)
 
     faults.add_faults((
@@ -735,6 +744,7 @@ def test_add_faults_replaces_none_with_zeros() -> None:
 
 
 def test_add_faults_rejects_both_none() -> None:
+    """add_faults raises ValueError when both X and Z arrays are None."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"At least one fault array must be provided."):
@@ -742,6 +752,7 @@ def test_add_faults_rejects_both_none() -> None:
 
 
 def test_copy_returns_independent_fault_list(fault_list: XZFaultList) -> None:
+    """Copying an XZFaultList returns an independent deep copy."""
     copied = fault_list.copy()
 
     copied.faults["X"][0, 0] = 0
@@ -752,6 +763,7 @@ def test_copy_returns_independent_fault_list(fault_list: XZFaultList) -> None:
 
 
 def test_iter_yields_fault_pairs_in_order(fault_list: XZFaultList) -> None:
+    """Iteration yields X,Z fault pairs in the same insertion order."""
     pairs = list(fault_list)
 
     assert len(pairs) == 2
@@ -762,6 +774,7 @@ def test_iter_yields_fault_pairs_in_order(fault_list: XZFaultList) -> None:
 
 
 def test_apply_cnot_updates_x_and_z_faults(fault_list: XZFaultList) -> None:
+    """Applying a CNOT updates both X and Z arrays according to circuit action."""
     updated = fault_list.apply_cnot(control=0, target=1, inplace=False)
 
     expected_x = np.array([[1, 1, 1], [0, 1, 0]], dtype=np.int8)
@@ -774,6 +787,7 @@ def test_apply_cnot_updates_x_and_z_faults(fault_list: XZFaultList) -> None:
 
 
 def test_apply_cnot_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
+    """Inplace CNOT application modifies the original fault list and returns it."""
     result = fault_list.apply_cnot(control=1, target=2, inplace=True)
 
     expected_x = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
@@ -785,6 +799,7 @@ def test_apply_cnot_inplace_modifies_current_fault_list(fault_list: XZFaultList)
 
 
 def test_apply_cnot_rejects_invalid_qubits(fault_list: XZFaultList) -> None:
+    """Invalid or identical qubit indices for CNOT raise ValueError."""
     with pytest.raises(ValueError, match=r"All qubits must be different."):
         fault_list.apply_cnot(control=1, target=1)
 
@@ -793,6 +808,7 @@ def test_apply_cnot_rejects_invalid_qubits(fault_list: XZFaultList) -> None:
 
 
 def test_apply_hadamard_swaps_x_and_z_on_target_qubit(fault_list: XZFaultList) -> None:
+    """Hadamard on a qubit swaps X and Z faults on that qubit position."""
     updated = fault_list.apply_hadamard(qubit=1, inplace=False)
 
     expected_x = np.array([[1, 1, 1], [0, 0, 0]], dtype=np.int8)
@@ -805,6 +821,7 @@ def test_apply_hadamard_swaps_x_and_z_on_target_qubit(fault_list: XZFaultList) -
 
 
 def test_apply_hadamard_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
+    """Inplace Hadamard modifies the fault list and returns the same object."""
     result = fault_list.apply_hadamard(qubit=0, inplace=True)
 
     expected_x = np.array([[0, 0, 1], [1, 1, 0]], dtype=np.int8)
@@ -816,16 +833,19 @@ def test_apply_hadamard_inplace_modifies_current_fault_list(fault_list: XZFaultL
 
 
 def test_apply_hadamard_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
+    """Applying Hadamard with an out-of-range qubit index raises ValueError."""
     with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
         fault_list.apply_hadamard(qubit=3)
 
 
 def test_apply_reset_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
+    """Applying reset with an out-of-range qubit index raises ValueError."""
     with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
         fault_list.apply_reset(qubit=3)
 
 
 def test_apply_ccz_updates_z_faults_non_inplace() -> None:
+    """Applying CCZ updates Z faults accordingly when not inplace."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
@@ -841,6 +861,7 @@ def test_apply_ccz_updates_z_faults_non_inplace() -> None:
 
 
 def test_apply_ccz_inplace_modifies_current_fault_list() -> None:
+    """Inplace CCZ modifies the fault list and returns it."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
@@ -855,6 +876,7 @@ def test_apply_ccz_inplace_modifies_current_fault_list() -> None:
 
 
 def test_apply_ccz_rejects_invalid_controls() -> None:
+    """CCZ rejects invalid or non-distinct control indices with ValueError."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"All qubits must be different."):
@@ -865,6 +887,7 @@ def test_apply_ccz_rejects_invalid_controls() -> None:
 
 
 def test_apply_ccx_rejects_invalid_qubits() -> None:
+    """CCX (Toffoli) rejects invalid or non-distinct qubit indices with ValueError."""
     faults = XZFaultList(num_qubits=3)
 
     with pytest.raises(ValueError, match=r"All qubits must be different."):
@@ -875,6 +898,7 @@ def test_apply_ccx_rejects_invalid_qubits() -> None:
 
 
 def test_apply_ccz_unit_tests() -> None:
+    """Unit tests: verify CCZ truth table mapping from input X to output X and Z."""
     # its always 0,1,2 for the controls
     # input x, output x, output z
     unit_tests = [
@@ -898,6 +922,7 @@ def test_apply_ccz_unit_tests() -> None:
         assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
 
 def test_apply_ccx_unit_tests() -> None:
+    """Unit tests: verify CCX (Toffoli) X-output mapping for control/target combinations."""
     # controls are always qubits 0 and 1, target is qubit 2
     # For CCX (Toffoli) with initial Z=0, the resulting X is (c1, c2, t + c1 & c2)
     unit_tests = [
@@ -922,6 +947,7 @@ def test_apply_ccx_unit_tests() -> None:
 
 
 def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> None:
+    """Reset clears X and Z errors on the given qubit without modifying source when not inplace."""
     updated = fault_list.apply_reset(qubit=1, inplace=False)
 
     expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
@@ -934,6 +960,7 @@ def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> No
 
 
 def test_apply_reset_clears_selected_qubit_errors_inplace(fault_list: XZFaultList) -> None:
+    """Inplace reset clears errors on the specified qubit and returns the same object."""
     result = fault_list.apply_reset(qubit=1, inplace=True)
 
     expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
@@ -946,7 +973,7 @@ def test_apply_reset_clears_selected_qubit_errors_inplace(fault_list: XZFaultLis
 
 # based on tests for mqt.qecc.circuit_synthesis.faults.coset_leader
 def test_reduce_to_coset_leaders_no_generators() -> None:
-    """Test coset leader reduction with no generators (should not modify faults)."""
+    """Coset leader reduction with no generators leaves faults unchanged."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
@@ -958,7 +985,7 @@ def test_reduce_to_coset_leaders_no_generators() -> None:
 
 
 def test_reduce_to_coset_leaders_x_generators() -> None:
-    """Test coset leader reduction with X generators."""
+    """Coset leader reduction applies X generators to reduce X faults to leaders."""
     faults = XZFaultList(num_qubits=3)
     # Add X fault that is in the stabilizer group
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
@@ -975,7 +1002,7 @@ def test_reduce_to_coset_leaders_x_generators() -> None:
 
 
 def test_reduce_to_coset_leaders_z_generators() -> None:
-    """Test coset leader reduction with Z generators."""
+    """Coset leader reduction applies Z generators to reduce Z faults to leaders."""
     faults = XZFaultList(num_qubits=3)
     # Add Z fault that is in the stabilizer group
     faults.add_fault((np.array([0, 0, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
@@ -992,7 +1019,7 @@ def test_reduce_to_coset_leaders_z_generators() -> None:
 
 
 def test_reduce_to_coset_leaders_both_generators() -> None:
-    """Test coset leader reduction with both X and Z generators."""
+    """Coset leader reduction handles simultaneous X and Z generator reduction."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
     faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 0], dtype=np.int8)))
@@ -1012,7 +1039,7 @@ def test_reduce_to_coset_leaders_both_generators() -> None:
 
 
 def test_reduce_to_coset_leaders_inplace() -> None:
-    """Test that inplace=True modifies the original fault list."""
+    """reduce_to_coset_leaders with inplace=True modifies the original fault list."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
@@ -1029,7 +1056,7 @@ def test_reduce_to_coset_leaders_inplace() -> None:
 
 
 def test_reduce_to_coset_leaders_not_inplace() -> None:
-    """Test that inplace=False returns a new independent fault list."""
+    """reduce_to_coset_leaders with inplace=False returns a new modified copy."""
     original = XZFaultList(num_qubits=3)
     original.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
@@ -1045,7 +1072,7 @@ def test_reduce_to_coset_leaders_not_inplace() -> None:
 
 
 def test_reduce_to_coset_leaders_multiple_faults() -> None:
-    """Test coset leader reduction with multiple faults."""
+    """Reduction correctly handles multiple faults, reducing those in stabilizer group."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
     faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
@@ -1062,7 +1089,7 @@ def test_reduce_to_coset_leaders_multiple_faults() -> None:
 
 
 def test_reduce_to_coset_leaders_invalid_generator_shape() -> None:
-    """Test that invalid generator shapes raise ValueError."""
+    """reduce_to_coset_leaders raises ValueError for generators with wrong shape."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
@@ -1074,7 +1101,7 @@ def test_reduce_to_coset_leaders_invalid_generator_shape() -> None:
 
 
 def test_reduce_to_coset_leaders_invalid_generator_dimension() -> None:
-    """Test that 1D generators raise ValueError."""
+    """reduce_to_coset_leaders raises ValueError when generators are 1D arrays."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
@@ -1086,7 +1113,7 @@ def test_reduce_to_coset_leaders_invalid_generator_dimension() -> None:
 
 
 def test_reduce_to_coset_leaders_empty_fault_list() -> None:
-    """Test coset leader reduction with an empty fault list."""
+    """Reduction on an empty fault list should remain empty and not error."""
     faults = XZFaultList(num_qubits=3)
 
     x_generators = np.array([[1, 0, 1]], dtype=np.int8)
@@ -1099,7 +1126,7 @@ def test_reduce_to_coset_leaders_empty_fault_list() -> None:
 
 
 def test_reduce_to_coset_leaders_empty_generators() -> None:
-    """Test coset leader reduction with empty generators (no reduction applied)."""
+    """Empty generator arrays result in no reduction and leave faults unchanged."""
     faults = XZFaultList(num_qubits=3)
     faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -638,6 +638,7 @@ def test_permute_qubits_inplace():
 
     assert fault_set != PureFaultSet.from_fault_array(faults), "Faults were not permuted correctly in place"
 
+
 """XZFaultList Tests"""
 
 

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -897,6 +897,29 @@ def test_apply_ccz_unit_tests() -> None:
         assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
         assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
 
+def test_apply_ccx_unit_tests() -> None:
+    # controls are always qubits 0 and 1, target is qubit 2
+    # For CCX (Toffoli) with initial Z=0, the resulting X is (c1, c2, t + c1 & c2)
+    unit_tests = [
+        ((0, 0, 0), (0, 0, 0)),
+        ((0, 0, 1), (0, 0, 1)),
+        ((0, 1, 0), (0, 1, 0)),
+        ((0, 1, 1), (0, 1, 1)),
+        ((1, 0, 0), (1, 0, 0)),
+        ((1, 0, 1), (1, 0, 1)),
+        ((1, 1, 0), (1, 1, 1)),
+        ((1, 1, 1), (1, 1, 0)),
+    ]
+
+    for input_x, expected_x in unit_tests:
+        faults = XZFaultList(num_qubits=3)
+        faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+
+        updated = faults.apply_ccx(control1=0, control2=1, target=2, inplace=False)
+
+        assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
+        assert np.array_equal(updated.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+
 
 def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> None:
     updated = fault_list.apply_reset(qubit=1, inplace=False)

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -910,6 +910,17 @@ def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> No
     assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
 
 
+def test_apply_reset_clears_selected_qubit_errors_inplace(fault_list: XZFaultList) -> None:
+    result = fault_list.apply_reset(qubit=1, inplace=True)
+
+    expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
+    expected_z = np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8)
+
+    assert result is fault_list
+    assert np.array_equal(fault_list.faults["X"], expected_x)
+    assert np.array_equal(fault_list.faults["Z"], expected_z)
+
+
 # based on tests for mqt.qecc.circuit_synthesis.faults.coset_leader
 def test_reduce_to_coset_leaders_no_generators() -> None:
     """Test coset leader reduction with no generators (should not modify faults)."""

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from mqt.qecc.circuit_synthesis.circuits import CNOTCircuit
-from mqt.qecc.circuit_synthesis.faults import PureFaultSet, coset_leader, stabilizer_equivalent, t_distinct, XZFaultList
+from mqt.qecc.circuit_synthesis.faults import PureFaultSet, XZFaultList, coset_leader, stabilizer_equivalent, t_distinct
 
 
 @pytest.fixture
@@ -639,444 +639,447 @@ def test_permute_qubits_inplace():
     assert fault_set != PureFaultSet.from_fault_array(faults), "Faults were not permuted correctly in place"
 
 """XZFaultList Tests"""
+
+
 @pytest.fixture
 def fault_list() -> XZFaultList:
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
-	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 1], dtype=np.int8)))
-	return faults
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 1], dtype=np.int8)))
+    return faults
 
 
 def test_initialization_creates_empty_fault_arrays() -> None:
-	faults = XZFaultList(num_qubits=4)
+    faults = XZFaultList(num_qubits=4)
 
-	assert faults.num_qubits == 4
-	assert np.array_equal(faults.faults["X"], np.zeros((0, 4), dtype=np.int8))
-	assert np.array_equal(faults.faults["Z"], np.zeros((0, 4), dtype=np.int8))
+    assert faults.num_qubits == 4
+    assert np.array_equal(faults.faults["X"], np.zeros((0, 4), dtype=np.int8))
+    assert np.array_equal(faults.faults["Z"], np.zeros((0, 4), dtype=np.int8))
 
 
 def test_add_fault_appends_x_and_z_rows() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	assert np.array_equal(faults.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
-	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(faults.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
 
 
 def test_add_fault_rejects_wrong_length() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"Faults must have length 3."):
-		faults.add_fault((np.array([1, 0], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    with pytest.raises(ValueError, match=r"Faults must have length 3."):
+        faults.add_fault((np.array([1, 0], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
 
 def test_add_fault_replaces_none_with_zeros() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	faults.add_fault((None, np.array([0, 1, 0], dtype=np.int8)))
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), None))
+    faults.add_fault((None, np.array([0, 1, 0], dtype=np.int8)))
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), None))
 
-	assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8))
-	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [0, 0, 0]], dtype=np.int8))
+    assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [0, 0, 0]], dtype=np.int8))
 
 
 def test_add_fault_rejects_both_none() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"At least one fault must be provided."):
-		faults.add_fault((None, None))
+    with pytest.raises(ValueError, match=r"At least one fault must be provided."):
+        faults.add_fault((None, None))
 
 
 def test_add_faults_appends_multiple_rows() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	faults.add_faults(
-		(
-			np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8),
-			np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
-		)
-	)
+    faults.add_faults((
+        np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8),
+        np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
+    ))
 
-	assert np.array_equal(faults.faults["X"], np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8))
-	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(faults.faults["X"], np.array([[1, 0, 0], [0, 1, 1]], dtype=np.int8))
+    assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
 
 
 def test_add_faults_rejects_wrong_column_count() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"Faults must have 3 columns."):
-		faults.add_faults(
-			(
-				np.array([[1, 0]], dtype=np.int8),
-				np.array([[0, 1]], dtype=np.int8),
-			)
-		)
+    with pytest.raises(ValueError, match=r"Faults must have 3 columns."):
+        faults.add_faults((
+            np.array([[1, 0]], dtype=np.int8),
+            np.array([[0, 1]], dtype=np.int8),
+        ))
 
 
 def test_add_faults_replaces_none_with_zeros() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	faults.add_faults(
-		(
-			None,
-			np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
-		)
-	)
-	faults.add_faults(
-		(
-			np.array([[1, 0, 1]], dtype=np.int8),
-			None,
-		)
-	)
+    faults.add_faults((
+        None,
+        np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8),
+    ))
+    faults.add_faults((
+        np.array([[1, 0, 1]], dtype=np.int8),
+        None,
+    ))
 
-	assert np.array_equal(
-		faults.faults["X"],
-		np.array([[0, 0, 0], [0, 0, 0], [1, 0, 1]], dtype=np.int8),
-	)
-	assert np.array_equal(
-		faults.faults["Z"],
-		np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0]], dtype=np.int8),
-	)
+    assert np.array_equal(
+        faults.faults["X"],
+        np.array([[0, 0, 0], [0, 0, 0], [1, 0, 1]], dtype=np.int8),
+    )
+    assert np.array_equal(
+        faults.faults["Z"],
+        np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0]], dtype=np.int8),
+    )
 
 
 def test_add_faults_rejects_both_none() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"At least one fault array must be provided."):
-		faults.add_faults((None, None))
+    with pytest.raises(ValueError, match=r"At least one fault array must be provided."):
+        faults.add_faults((None, None))
 
 
 def test_copy_returns_independent_fault_list(fault_list: XZFaultList) -> None:
-	copied = fault_list.copy()
+    copied = fault_list.copy()
 
-	copied.faults["X"][0, 0] = 0
-	copied.faults["Z"][1, 2] = 0
+    copied.faults["X"][0, 0] = 0
+    copied.faults["Z"][1, 2] = 0
 
-	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
-	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
 
 
 def test_iter_yields_fault_pairs_in_order(fault_list: XZFaultList) -> None:
-	pairs = list(fault_list)
+    pairs = list(fault_list)
 
-	assert len(pairs) == 2
-	assert np.array_equal(pairs[0][0], np.array([1, 0, 1], dtype=np.int8))
-	assert np.array_equal(pairs[0][1], np.array([0, 1, 0], dtype=np.int8))
-	assert np.array_equal(pairs[1][0], np.array([0, 1, 0], dtype=np.int8))
-	assert np.array_equal(pairs[1][1], np.array([1, 0, 1], dtype=np.int8))
+    assert len(pairs) == 2
+    assert np.array_equal(pairs[0][0], np.array([1, 0, 1], dtype=np.int8))
+    assert np.array_equal(pairs[0][1], np.array([0, 1, 0], dtype=np.int8))
+    assert np.array_equal(pairs[1][0], np.array([0, 1, 0], dtype=np.int8))
+    assert np.array_equal(pairs[1][1], np.array([1, 0, 1], dtype=np.int8))
 
 
 def test_apply_cnot_updates_x_and_z_faults(fault_list: XZFaultList) -> None:
-	updated = fault_list.apply_cnot(control=0, target=1, inplace=False)
+    updated = fault_list.apply_cnot(control=0, target=1, inplace=False)
 
-	expected_x = np.array([[1, 1, 1], [0, 1, 0]], dtype=np.int8)
-	expected_z = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 1, 1], [0, 1, 0]], dtype=np.int8)
+    expected_z = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.int8)
 
-	assert np.array_equal(updated.faults["X"], expected_x)
-	assert np.array_equal(updated.faults["Z"], expected_z)
-	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
-	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(updated.faults["X"], expected_x)
+    assert np.array_equal(updated.faults["Z"], expected_z)
+    assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
 
 
 def test_apply_cnot_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
-	result = fault_list.apply_cnot(control=1, target=2, inplace=True)
+    result = fault_list.apply_cnot(control=1, target=2, inplace=True)
 
-	expected_x = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
-	expected_z = np.array([[0, 1, 0], [1, 1, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.int8)
+    expected_z = np.array([[0, 1, 0], [1, 1, 1]], dtype=np.int8)
 
-	assert result is fault_list
-	assert np.array_equal(fault_list.faults["X"], expected_x)
-	assert np.array_equal(fault_list.faults["Z"], expected_z)
+    assert result is fault_list
+    assert np.array_equal(fault_list.faults["X"], expected_x)
+    assert np.array_equal(fault_list.faults["Z"], expected_z)
 
 
 def test_apply_cnot_rejects_invalid_qubits(fault_list: XZFaultList) -> None:
-	with pytest.raises(ValueError, match=r"All qubits must be different."):
-		fault_list.apply_cnot(control=1, target=1)
+    with pytest.raises(ValueError, match=r"All qubits must be different."):
+        fault_list.apply_cnot(control=1, target=1)
 
-	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
-		fault_list.apply_cnot(control=3, target=1)
+    with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+        fault_list.apply_cnot(control=3, target=1)
 
 
 def test_apply_hadamard_swaps_x_and_z_on_target_qubit(fault_list: XZFaultList) -> None:
-	updated = fault_list.apply_hadamard(qubit=1, inplace=False)
+    updated = fault_list.apply_hadamard(qubit=1, inplace=False)
 
-	expected_x = np.array([[1, 1, 1], [0, 0, 0]], dtype=np.int8)
-	expected_z = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 1, 1], [0, 0, 0]], dtype=np.int8)
+    expected_z = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.int8)
 
-	assert np.array_equal(updated.faults["X"], expected_x)
-	assert np.array_equal(updated.faults["Z"], expected_z)
-	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
-	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(updated.faults["X"], expected_x)
+    assert np.array_equal(updated.faults["Z"], expected_z)
+    assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
 
 
 def test_apply_hadamard_inplace_modifies_current_fault_list(fault_list: XZFaultList) -> None:
-	result = fault_list.apply_hadamard(qubit=0, inplace=True)
+    result = fault_list.apply_hadamard(qubit=0, inplace=True)
 
-	expected_x = np.array([[0, 0, 1], [1, 1, 0]], dtype=np.int8)
-	expected_z = np.array([[1, 1, 0], [0, 0, 1]], dtype=np.int8)
+    expected_x = np.array([[0, 0, 1], [1, 1, 0]], dtype=np.int8)
+    expected_z = np.array([[1, 1, 0], [0, 0, 1]], dtype=np.int8)
 
-	assert result is fault_list
-	assert np.array_equal(fault_list.faults["X"], expected_x)
-	assert np.array_equal(fault_list.faults["Z"], expected_z)
+    assert result is fault_list
+    assert np.array_equal(fault_list.faults["X"], expected_x)
+    assert np.array_equal(fault_list.faults["Z"], expected_z)
 
 
 def test_apply_hadamard_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
-	with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
-		fault_list.apply_hadamard(qubit=3)
+    with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
+        fault_list.apply_hadamard(qubit=3)
 
 
 def test_apply_reset_rejects_invalid_qubit(fault_list: XZFaultList) -> None:
-	with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
-		fault_list.apply_reset(qubit=3)
+    with pytest.raises(ValueError, match=r"Qubit index must be between 0 and 2."):
+        fault_list.apply_reset(qubit=3)
 
 
 def test_apply_ccz_updates_z_faults_non_inplace() -> None:
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
-	updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
+    updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
 
-	expected_x = np.array([[1, 1, 1]], dtype=np.int8)
-	expected_z = np.array([[1, 1, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 1, 1]], dtype=np.int8)
+    expected_z = np.array([[1, 1, 1]], dtype=np.int8)
 
-	assert np.array_equal(updated.faults["X"], expected_x)
-	assert np.array_equal(updated.faults["Z"], expected_z)
-	assert np.array_equal(faults.faults["X"], np.array([[1, 1, 1]], dtype=np.int8))
-	assert np.array_equal(faults.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+    assert np.array_equal(updated.faults["X"], expected_x)
+    assert np.array_equal(updated.faults["Z"], expected_z)
+    assert np.array_equal(faults.faults["X"], np.array([[1, 1, 1]], dtype=np.int8))
+    assert np.array_equal(faults.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
 
 
 def test_apply_ccz_inplace_modifies_current_fault_list() -> None:
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
-	result = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=True)
+    result = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=True)
 
-	expected_x = np.array([[1, 1, 1]], dtype=np.int8)
-	expected_z = np.array([[1, 1, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 1, 1]], dtype=np.int8)
+    expected_z = np.array([[1, 1, 1]], dtype=np.int8)
 
-	assert result is faults
-	assert np.array_equal(faults.faults["X"], expected_x)
-	assert np.array_equal(faults.faults["Z"], expected_z)
+    assert result is faults
+    assert np.array_equal(faults.faults["X"], expected_x)
+    assert np.array_equal(faults.faults["Z"], expected_z)
 
 
 def test_apply_ccz_rejects_invalid_controls() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"All qubits must be different."):
-		faults.apply_ccz(control1=0, control2=0, control3=2)
+    with pytest.raises(ValueError, match=r"All qubits must be different."):
+        faults.apply_ccz(control1=0, control2=0, control3=2)
 
-	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
-		faults.apply_ccz(control1=0, control2=1, control3=3)
+    with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+        faults.apply_ccz(control1=0, control2=1, control3=3)
+
 
 def test_apply_ccx_rejects_invalid_qubits() -> None:
-	faults = XZFaultList(num_qubits=3)
+    faults = XZFaultList(num_qubits=3)
 
-	with pytest.raises(ValueError, match=r"All qubits must be different."):
-		faults.apply_ccx(control1=0, control2=1, target=1)
+    with pytest.raises(ValueError, match=r"All qubits must be different."):
+        faults.apply_ccx(control1=0, control2=1, target=1)
 
-	with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
-		faults.apply_ccx(control1=0, control2=1, target=3)
+    with pytest.raises(ValueError, match=r"Qubit indices must be between 0 and 2."):
+        faults.apply_ccx(control1=0, control2=1, target=3)
+
 
 def test_apply_ccz_unit_tests() -> None:
-	# its always 0,1,2 for the controls
-	# input x, output x, output z
-	unit_tests = [
-		[(0, 0, 0), (0, 0, 0), (0, 0, 0)],
-		[(0, 0, 1), (0, 0, 1), (0, 0, 0)],
-		[(0, 1, 0), (0, 1, 0), (0, 0, 0)],
-		[(0, 1, 1), (0, 1, 1), (1, 0, 0)],
-		[(1, 0, 0), (1, 0, 0), (0, 0, 0)],
-		[(1, 0, 1), (1, 0, 1), (0, 1, 0)],
-		[(1, 1, 0), (1, 1, 0), (0, 0, 1)],
-		[(1, 1, 1), (1, 1, 1), (1, 1, 1)],
-	]
-	
-	for input_x, expected_x, expected_z in unit_tests:
-		faults = XZFaultList(num_qubits=3)
-		faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    # its always 0,1,2 for the controls
+    # input x, output x, output z
+    unit_tests = [
+        [(0, 0, 0), (0, 0, 0), (0, 0, 0)],
+        [(0, 0, 1), (0, 0, 1), (0, 0, 0)],
+        [(0, 1, 0), (0, 1, 0), (0, 0, 0)],
+        [(0, 1, 1), (0, 1, 1), (1, 0, 0)],
+        [(1, 0, 0), (1, 0, 0), (0, 0, 0)],
+        [(1, 0, 1), (1, 0, 1), (0, 1, 0)],
+        [(1, 1, 0), (1, 1, 0), (0, 0, 1)],
+        [(1, 1, 1), (1, 1, 1), (1, 1, 1)],
+    ]
 
-		updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
+    for input_x, expected_x, expected_z in unit_tests:
+        faults = XZFaultList(num_qubits=3)
+        faults.add_fault((np.array(input_x, dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
-		assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
-		assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
+        updated = faults.apply_ccz(control1=0, control2=1, control3=2, inplace=False)
+
+        assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
+        assert np.array_equal(updated.faults["Z"], np.array([expected_z], dtype=np.int8))
 
 
 def test_apply_reset_clears_selected_qubit_errors(fault_list: XZFaultList) -> None:
-	updated = fault_list.apply_reset(qubit=1, inplace=False)
+    updated = fault_list.apply_reset(qubit=1, inplace=False)
 
-	expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
-	expected_z = np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8)
+    expected_x = np.array([[1, 0, 1], [0, 0, 0]], dtype=np.int8)
+    expected_z = np.array([[0, 0, 0], [1, 0, 1]], dtype=np.int8)
 
-	assert np.array_equal(updated.faults["X"], expected_x)
-	assert np.array_equal(updated.faults["Z"], expected_z)
-	assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
-	assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(updated.faults["X"], expected_x)
+    assert np.array_equal(updated.faults["Z"], expected_z)
+    assert np.array_equal(fault_list.faults["X"], np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(fault_list.faults["Z"], np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8))
+
 
 # based on tests for mqt.qecc.circuit_synthesis.faults.coset_leader
 def test_reduce_to_coset_leaders_no_generators() -> None:
-	"""Test coset leader reduction with no generators (should not modify faults)."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test coset leader reduction with no generators (should not modify faults)."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	# No generators - faults should remain unchanged
-	reduced = faults.reduce_to_coset_leaders((None, None), inplace=False)
+    # No generators - faults should remain unchanged
+    reduced = faults.reduce_to_coset_leaders((None, None), inplace=False)
 
-	assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
-	assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+    assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_x_generators() -> None:
-	"""Test coset leader reduction with X generators."""
-	faults = XZFaultList(num_qubits=3)
-	# Add X fault that is in the stabilizer group
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    """Test coset leader reduction with X generators."""
+    faults = XZFaultList(num_qubits=3)
+    # Add X fault that is in the stabilizer group
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
-	# X generator that matches the X fault
-	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    # X generator that matches the X fault
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
 
-	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
-	# X fault should be reduced to zero (it's in the stabilizer group)
-	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
-	# Z fault should remain unchanged
-	assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+    # X fault should be reduced to zero (it's in the stabilizer group)
+    assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+    # Z fault should remain unchanged
+    assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_z_generators() -> None:
-	"""Test coset leader reduction with Z generators."""
-	faults = XZFaultList(num_qubits=3)
-	# Add Z fault that is in the stabilizer group
-	faults.add_fault((np.array([0, 0, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
+    """Test coset leader reduction with Z generators."""
+    faults = XZFaultList(num_qubits=3)
+    # Add Z fault that is in the stabilizer group
+    faults.add_fault((np.array([0, 0, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
 
-	# Z generator that matches the Z fault
-	z_generators = np.array([[0, 1, 1]], dtype=np.int8)
+    # Z generator that matches the Z fault
+    z_generators = np.array([[0, 1, 1]], dtype=np.int8)
 
-	reduced = faults.reduce_to_coset_leaders((None, z_generators), inplace=False)
+    reduced = faults.reduce_to_coset_leaders((None, z_generators), inplace=False)
 
-	# X fault should remain unchanged
-	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
-	# Z fault should be reduced to zero
-	assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
+    # X fault should remain unchanged
+    assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+    # Z fault should be reduced to zero
+    assert np.array_equal(reduced.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_both_generators() -> None:
-	"""Test coset leader reduction with both X and Z generators."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
-	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 0], dtype=np.int8)))
+    """Test coset leader reduction with both X and Z generators."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)))
+    faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([1, 0, 0], dtype=np.int8)))
 
-	# Generators that match the faults
-	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
-	z_generators = np.array([[0, 1, 1]], dtype=np.int8)
+    # Generators that match the faults
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    z_generators = np.array([[0, 1, 1]], dtype=np.int8)
 
-	reduced = faults.reduce_to_coset_leaders((x_generators, z_generators), inplace=False)
+    reduced = faults.reduce_to_coset_leaders((x_generators, z_generators), inplace=False)
 
-	# Both matching faults should be reduced to zero
-	assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
-	assert np.array_equal(reduced.faults["Z"][0], np.array([0, 0, 0], dtype=np.int8))
-	# Non-matching faults should be reduced to their coset leaders
-	assert reduced.faults["X"].shape[0] == 2
-	assert reduced.faults["Z"].shape[0] == 2
+    # Both matching faults should be reduced to zero
+    assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
+    assert np.array_equal(reduced.faults["Z"][0], np.array([0, 0, 0], dtype=np.int8))
+    # Non-matching faults should be reduced to their coset leaders
+    assert reduced.faults["X"].shape[0] == 2
+    assert reduced.faults["Z"].shape[0] == 2
 
 
 def test_reduce_to_coset_leaders_inplace() -> None:
-	"""Test that inplace=True modifies the original fault list."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test that inplace=True modifies the original fault list."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
 
-	result = faults.reduce_to_coset_leaders((x_generators, None), inplace=True)
+    result = faults.reduce_to_coset_leaders((x_generators, None), inplace=True)
 
-	# Result should be the same object
-	assert result is faults
-	# X fault should be reduced
-	assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
-	# Z fault should remain unchanged
-	assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+    # Result should be the same object
+    assert result is faults
+    # X fault should be reduced
+    assert np.array_equal(faults.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+    # Z fault should remain unchanged
+    assert np.array_equal(faults.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_not_inplace() -> None:
-	"""Test that inplace=False returns a new independent fault list."""
-	original = XZFaultList(num_qubits=3)
-	original.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test that inplace=False returns a new independent fault list."""
+    original = XZFaultList(num_qubits=3)
+    original.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
-	reduced = original.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    reduced = original.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
-	# Result should be a different object
-	assert reduced is not original
-	# Reduced fault list should be modified
-	assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
-	# Original should remain unchanged
-	assert np.array_equal(original.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+    # Result should be a different object
+    assert reduced is not original
+    # Reduced fault list should be modified
+    assert np.array_equal(reduced.faults["X"], np.array([[0, 0, 0]], dtype=np.int8))
+    # Original should remain unchanged
+    assert np.array_equal(original.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_multiple_faults() -> None:
-	"""Test coset leader reduction with multiple faults."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
-	faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
-	faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    """Test coset leader reduction with multiple faults."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    faults.add_fault((np.array([0, 1, 0], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
+    faults.add_fault((np.array([1, 1, 1], dtype=np.int8), np.array([0, 0, 0], dtype=np.int8)))
 
-	# Two X generators
-	x_generators = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+    # Two X generators
+    x_generators = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
 
-	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
-	# First two faults are in the stabilizer group, third should be reduced to coset leader
-	assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
-	assert np.array_equal(reduced.faults["X"][1], np.array([0, 0, 0], dtype=np.int8))
+    # First two faults are in the stabilizer group, third should be reduced to coset leader
+    assert np.array_equal(reduced.faults["X"][0], np.array([0, 0, 0], dtype=np.int8))
+    assert np.array_equal(reduced.faults["X"][1], np.array([0, 0, 0], dtype=np.int8))
 
 
 def test_reduce_to_coset_leaders_invalid_generator_shape() -> None:
-	"""Test that invalid generator shapes raise ValueError."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test that invalid generator shapes raise ValueError."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	# Wrong number of columns in generator
-	x_generators = np.array([[1, 0]], dtype=np.int8)
+    # Wrong number of columns in generator
+    x_generators = np.array([[1, 0]], dtype=np.int8)
 
-	with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
-		faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
+        faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
 
 def test_reduce_to_coset_leaders_invalid_generator_dimension() -> None:
-	"""Test that 1D generators raise ValueError."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test that 1D generators raise ValueError."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	# 1D array instead of 2D
-	x_generators = np.array([1, 0, 1], dtype=np.int8)
+    # 1D array instead of 2D
+    x_generators = np.array([1, 0, 1], dtype=np.int8)
 
-	with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
-		faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    with pytest.raises(ValueError, match=r"Generators must be a 2D array with 3 columns."):
+        faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
 
 def test_reduce_to_coset_leaders_empty_fault_list() -> None:
-	"""Test coset leader reduction with an empty fault list."""
-	faults = XZFaultList(num_qubits=3)
-	
-	x_generators = np.array([[1, 0, 1]], dtype=np.int8)
+    """Test coset leader reduction with an empty fault list."""
+    faults = XZFaultList(num_qubits=3)
 
-	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    x_generators = np.array([[1, 0, 1]], dtype=np.int8)
 
-	# Should remain empty
-	assert reduced.faults["X"].shape == (0, 3)
-	assert reduced.faults["Z"].shape == (0, 3)
+    reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+
+    # Should remain empty
+    assert reduced.faults["X"].shape == (0, 3)
+    assert reduced.faults["Z"].shape == (0, 3)
 
 
 def test_reduce_to_coset_leaders_empty_generators() -> None:
-	"""Test coset leader reduction with empty generators (no reduction applied)."""
-	faults = XZFaultList(num_qubits=3)
-	faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
+    """Test coset leader reduction with empty generators (no reduction applied)."""
+    faults = XZFaultList(num_qubits=3)
+    faults.add_fault((np.array([1, 0, 1], dtype=np.int8), np.array([0, 1, 0], dtype=np.int8)))
 
-	# Empty generators
-	x_generators = np.empty((0, 3), dtype=np.int8)
+    # Empty generators
+    x_generators = np.empty((0, 3), dtype=np.int8)
 
-	reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
+    reduced = faults.reduce_to_coset_leaders((x_generators, None), inplace=False)
 
+<<<<<<< HEAD
 	# Faults should remain unchanged
 	assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
 	assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+=======
+    # Faults should remain unchanged
+    assert np.array_equal(reduced.faults["X"], np.array([[1, 0, 1]], dtype=np.int8))
+    assert np.array_equal(reduced.faults["Z"], np.array([[0, 1, 0]], dtype=np.int8))
+>>>>>>> d0b4bc68 (🎨 pre-commit fixes)

--- a/tests/circuit_synthesis/test_faults.py
+++ b/tests/circuit_synthesis/test_faults.py
@@ -933,7 +933,12 @@ def test_apply_ccz_unit_tests() -> None:
         [(0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)],
         [(0, 0, 1), (0, 0, 0), (0, 0, 1), (0, 0, 0)],
         [(0, 1, 0), (0, 0, 0), (0, 1, 0), (0, 0, 0)],
-        [(0, 1, 1), (1, 0, 0), (0, 1, 1), (0, 0, 0)], # NOTE: XOR with the existing 1,0,0 to give 0,0,0 (question is whether they should cancel)
+        [
+            (0, 1, 1),
+            (1, 0, 0),
+            (0, 1, 1),
+            (0, 0, 0),
+        ],  # NOTE: XOR with the existing 1,0,0 to give 0,0,0 (question is whether they should cancel)
         [(1, 0, 0), (0, 0, 0), (1, 0, 0), (0, 0, 0)],
         [(1, 0, 1), (0, 0, 0), (1, 0, 1), (0, 1, 0)],
         [(1, 1, 1), (1, 0, 0), (1, 1, 1), (0, 1, 1)],
@@ -974,7 +979,9 @@ def test_apply_ccx_unit_tests() -> None:
         assert np.array_equal(updated.faults["X"], np.array([expected_x], dtype=np.int8))
         assert np.array_equal(updated.faults["Z"], np.array([[0, 0, 0]], dtype=np.int8))
 
+
 def test_apply_ccx_unit_tests_inplace() -> None:
+    """Unit tests: verify CCX (Toffoli) inplace = True does indeed change the faults in-place."""
     inplace_faults = XZFaultList(num_qubits=3)
     inplace_faults.add_fault((np.array([1, 1, 0], dtype=np.int8), np.array([0, 0, 1], dtype=np.int8)))
 


### PR DESCRIPTION
## Description

Expands on the idea of `PureFaultSet` by having a list (i.e. stable order) of coupled $X$- and $Z$-Faults on which gates such as CNOTs, H, Reset may be applied. 

This PR is a fresh copy of the draft PR #712 without the edits to `PureFaultSet`, so that it can already be merged into main. Commits were picked from the branch XZFaultList.
In this case #690 need not be merged.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] ~I have updated the documentation to reflect these changes.~
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qecc/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
