### PR TITLE
⚡️ Debloat Test Runtime

### DIFF
--- a/src/mqt/qecc/circuit_synthesis/simulation.py
+++ b/src/mqt/qecc/circuit_synthesis/simulation.py
@@ -633,24 +633,29 @@ class LutDecoder:
 
             # Create a generator of all combinations for this weight.
             comb_iter = itertools.combinations(range(n_qubits), weight)
-            # Split the combinations into chunks.
-            chunks = _chunked_iterable(comb_iter, chunk_size)
+            # Split the combinations into chunks, allowing us to size the pool to the actual work (small codes yield a single chunk).
+            chunks = list(_chunked_iterable(comb_iter, chunk_size))
 
             weight_dict: dict[bytes, npt.NDArray[np.int8]] = {}
-            with concurrent.futures.ProcessPoolExecutor(max_workers=num_workers) as executor:
-                d2 = weight_dict.copy()
-                futures = [
-                    executor.submit(_process_combinations_chunk, chunk, checks, n_qubits, d2) for chunk in chunks
-                ]
-                if print_progress:
-                    for future in tqdm(
-                        concurrent.futures.as_completed(futures), total=len(futures), desc=f"Weight {weight}"
-                    ):
-                        _merge_into(weight_dict, future.result())
+            d2 = weight_dict.copy()
+            if len(chunks) <= 1:
+                # Spawning worker processes for a single chunk is overhead
+                for chunk in chunks:
+                    _merge_into(weight_dict, _process_combinations_chunk(chunk, checks, n_qubits, d2))
+            else:
+                with concurrent.futures.ProcessPoolExecutor(max_workers=min(num_workers, len(chunks))) as executor:
+                    futures = [
+                        executor.submit(_process_combinations_chunk, chunk, checks, n_qubits, d2) for chunk in chunks
+                    ]
+                    if print_progress:
+                        for future in tqdm(
+                            concurrent.futures.as_completed(futures), total=len(futures), desc=f"Weight {weight}"
+                        ):
+                            _merge_into(weight_dict, future.result())
 
-                else:
-                    for future in concurrent.futures.as_completed(futures):
-                        _merge_into(weight_dict, future.result())
+                    else:
+                        for future in concurrent.futures.as_completed(futures):
+                            _merge_into(weight_dict, future.result())
 
             _merge_into(global_lut, weight_dict)
 

--- a/src/mqt/qecc/circuit_synthesis/simulation.py
+++ b/src/mqt/qecc/circuit_synthesis/simulation.py
@@ -13,6 +13,7 @@ import concurrent.futures
 import itertools
 import logging
 import math
+import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -609,14 +610,17 @@ class LutDecoder:
 
     @staticmethod
     def _generate_lut(
-        checks: npt.NDArray[np.int8], chunk_size: int = 2**20, num_workers: int = 8, print_progress: bool = False
+        checks: npt.NDArray[np.int8],
+        chunk_size: int = 2**20,
+        num_workers: int | None = None,
+        print_progress: bool = False,
     ) -> dict[bytes, npt.NDArray[np.int8]]:
         """Generate a lookup table (LUT) for error correction by processing the state space in chunks, in parallel, and displaying a progress bar.
 
         Parameters:
             checks: The stabilizer check matrix (binary).
             chunk_size: Number of states processed per chunk.
-            num_workers: Number of parallel worker processes (default: use available cores).
+            num_workers: Number of parallel worker processes (default: the number of available cores).
             print_progress: Whether to print progress information.
 
         Returns:
@@ -633,19 +637,22 @@ class LutDecoder:
 
             # Create a generator of all combinations for this weight.
             comb_iter = itertools.combinations(range(n_qubits), weight)
-            # Split the combinations into chunks, allowing us to size the pool to the actual work (small codes yield a single chunk).
-            chunks = list(_chunked_iterable(comb_iter, chunk_size))
+            # Split the combinations into chunks. The count is known up front, so the pool can be sized to the
+            # actual work (small codes yield a single chunk) without materializing the chunks themselves.
+            num_chunks = (total_combinations + chunk_size - 1) // chunk_size
+            chunks = _chunked_iterable(comb_iter, chunk_size)
 
             weight_dict: dict[bytes, npt.NDArray[np.int8]] = {}
-            d2 = weight_dict.copy()
-            if len(chunks) <= 1:
-                # Spawning worker processes for a single chunk is overhead
-                for chunk in chunks:
-                    _merge_into(weight_dict, _process_combinations_chunk(chunk, checks, n_qubits, d2))
+            if num_chunks <= 1:
+                # Spawning worker processes for a single chunk is pure overhead.
+                chunk_iter = tqdm(chunks, total=num_chunks, desc=f"Weight {weight}") if print_progress else chunks
+                for chunk in chunk_iter:
+                    _merge_into(weight_dict, _process_combinations_chunk(chunk, checks, n_qubits, {}))
             else:
-                with concurrent.futures.ProcessPoolExecutor(max_workers=min(num_workers, len(chunks))) as executor:
+                workers = num_workers if num_workers is not None else os.cpu_count() or 1
+                with concurrent.futures.ProcessPoolExecutor(max_workers=min(workers, num_chunks)) as executor:
                     futures = [
-                        executor.submit(_process_combinations_chunk, chunk, checks, n_qubits, d2) for chunk in chunks
+                        executor.submit(_process_combinations_chunk, chunk, checks, n_qubits, {}) for chunk in chunks
                     ]
                     if print_progress:
                         for future in tqdm(

--- a/tests/circuit_synthesis/test_simulation.py
+++ b/tests/circuit_synthesis/test_simulation.py
@@ -132,7 +132,7 @@ def test_lut_chunked_parallel(print_progress: bool) -> None:
     """Test that the multi-chunk (parallel) LUT generation agrees with the single-chunk one."""
     checks = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.int8)
 
-    serial_lut = LutDecoder._generate_lut(checks)  # ruff: ignore[private-member-access]
+    serial_lut = LutDecoder._generate_lut(checks, print_progress=print_progress)  # ruff: ignore[private-member-access]
     parallel_lut = LutDecoder._generate_lut(  # ruff: ignore[private-member-access]
         checks, chunk_size=1, num_workers=2, print_progress=print_progress
     )

--- a/tests/circuit_synthesis/test_simulation.py
+++ b/tests/circuit_synthesis/test_simulation.py
@@ -127,6 +127,23 @@ def test_lut(steane_code: CSSCode) -> None:
     assert np.sum(estimate_3) == 0
 
 
+@pytest.mark.parametrize("print_progress", [False, True])
+def test_lut_chunked_parallel(print_progress: bool) -> None:
+    """Test that the multi-chunk (parallel) LUT generation agrees with the single-chunk one."""
+    checks = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.int8)
+
+    serial_lut = LutDecoder._generate_lut(checks)  # ruff: ignore[private-member-access]
+    parallel_lut = LutDecoder._generate_lut(  # ruff: ignore[private-member-access]
+        checks, chunk_size=1, num_workers=2, print_progress=print_progress
+    )
+
+    assert set(parallel_lut) == set(serial_lut)
+    assert len(parallel_lut) == 2 ** checks.shape[0]  # all syndromes are covered
+    for syndrome, state in parallel_lut.items():
+        assert ((checks @ state) % 2).astype(np.int8).tobytes() == syndrome
+        assert np.sum(state) == np.sum(serial_lut[syndrome])  # same (minimal) error weight
+
+
 def test_ideal_sim(steane_code: CSSCode, non_ft_steane_zero: QuantumCircuit) -> None:
     """Test the simulation of a non fault-tolerant state preparation circuit for the Steane |0>."""
     noise = make_uniform_error_model(0)

--- a/tests/cococo/test_lattice_router.py
+++ b/tests/cococo/test_lattice_router.py
@@ -150,7 +150,7 @@ def test_teleportationrouter():
         g, data_qubit_locs, factories, valid_path="cc", t=t, metric="exact", use_dag=True, seed=1
     )
 
-    max_iters = 100
+    max_iters = 20  # enough to hit all relevant code paths; larger values only lengthen the test
     T_start = 100.0  # ruff:ignore[non-lowercase-variable-in-function]
     T_end = 0.1  # ruff:ignore[non-lowercase-variable-in-function]
     alpha = 0.95

--- a/tests/cococo/test_lattice_router.py
+++ b/tests/cococo/test_lattice_router.py
@@ -141,16 +141,16 @@ def test_teleportationrouter():
 
     q = len(data_qubit_locs)
     # j = 8
-    num_gates = int(q * 1.2)
+    num_gates = int(q * 2.4)
     pairs = circuit_construction.generate_random_circuit(q, num_gates, tgate=True, ratio=0.8)  # circuit with t gates
 
     terminal_pairs = layouts.translate_layout_circuit(pairs, cast("Layout", layout))  # let's stick to the simple layout
 
     router = utils.TeleportationRouter(
-        g, data_qubit_locs, factories, valid_path="cc", t=t, metric="exact", use_dag=True, seed=1
+        g, data_qubit_locs, factories, valid_path="cc", t=t, metric="exact", use_dag=True, seed=7
     )
 
-    max_iters = 20  # enough to hit all relevant code paths; larger values only lengthen the test
+    max_iters = 2  # enough to hit all relevant code paths; larger values only lengthen the test
     T_start = 100.0  # ruff:ignore[non-lowercase-variable-in-function]
     T_end = 0.1  # ruff:ignore[non-lowercase-variable-in-function]
     alpha = 0.95


### PR DESCRIPTION
## Description

Small PR primarily reducing test runtime (and consequently CI runtime), while maintaining accuracy (only removing unnecessary computations, without removing tested code paths). 

**Change 1** (test-only): Tweak parameters in `test_lattice_router.py::test_teleportationrouter` to reduce `max_iters` while keeping all tested code paths.

**Change 2**: Add explicit handling of small cases in `LutDecoder._generate_lut()`, so that it does not spawn 8 subprocesses for a single chunk (like in tests).

Assisted-by: Claude Opus 5 via Claude Code

## Checklist


- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qecc/blob/main/docs/ai_usage.md).
- [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
